### PR TITLE
feat(DetailTabs): generic tabbed detail viewer (Opción B refactor)

### DIFF
--- a/src/DetailTabs.tsx
+++ b/src/DetailTabs.tsx
@@ -1,0 +1,150 @@
+import { useState, useEffect, type ReactNode } from 'react';
+
+/**
+ * Generic tabbed detail viewer with optional premium gating.
+ * Domain-agnostic: each tab provides its own `content` ReactNode.
+ *
+ * For nutrition-specific tabs (recipe, hydration, timing, etc.)
+ * see `MealDetailTabs` which wraps `DetailTabs` with a fixed catalog.
+ */
+
+export interface DetailTabDefinition<TId extends string = string> {
+  /** Unique identifier — used in URLs, ARIA, and state */
+  id: TId;
+  /** Visible label */
+  label: string;
+  /** Optional icon (emoji or React node) rendered before label */
+  icon?: ReactNode;
+  /** When true, tab content is gated behind premium */
+  premium?: boolean;
+  /** Panel content rendered when this tab is active and unlocked */
+  content: ReactNode;
+}
+
+export interface DetailTabsProps<TId extends string = string> {
+  /** Tab definitions (order respected) */
+  tabs: DetailTabDefinition<TId>[];
+  /** Default active tab id (uncontrolled mode) — first tab if omitted */
+  defaultTab?: TId;
+  /** Controlled active tab id (overrides internal state) */
+  activeTab?: TId;
+  /** Notified when user switches tabs */
+  onTabChange?: (id: TId) => void;
+  /** Premium status — when false, tabs marked `premium: true` show `lockedContent` */
+  isPremium?: boolean;
+  /**
+   * Content shown for premium tabs when `isPremium=false`.
+   * - ReactNode: same content for every locked tab
+   * - Function: receives the locked tab definition and returns a custom node
+   */
+  lockedContent?: ReactNode | ((tab: DetailTabDefinition<TId>) => ReactNode);
+  /** ARIA label for the tablist (defaults to "Detalle") */
+  ariaLabel?: string;
+  /** Optional id prefix for ARIA wiring (defaults to "detail") */
+  idPrefix?: string;
+  className?: string;
+}
+
+export function DetailTabs<TId extends string = string>({
+  tabs,
+  defaultTab,
+  activeTab,
+  onTabChange,
+  isPremium = true,
+  lockedContent,
+  ariaLabel = 'Detalle',
+  idPrefix = 'detail',
+  className = '',
+}: DetailTabsProps<TId>) {
+  const initialTab = defaultTab ?? tabs[0]?.id;
+  const [internalActive, setInternalActive] = useState<TId | undefined>(initialTab);
+  const active = activeTab ?? internalActive;
+
+  // If controlled `activeTab` changes externally, no internal sync needed
+  // (we just read `active`). If uncontrolled and `defaultTab` changes, follow it.
+  useEffect(() => {
+    if (activeTab === undefined && defaultTab !== undefined) {
+      setInternalActive(defaultTab);
+    }
+  }, [defaultTab, activeTab]);
+
+  if (!active || tabs.length === 0) {
+    return null;
+  }
+
+  function selectTab(id: TId) {
+    if (activeTab === undefined) {
+      setInternalActive(id);
+    }
+    onTabChange?.(id);
+  }
+
+  const activeTabDef = tabs.find((t) => t.id === active);
+
+  function renderPanel(): ReactNode {
+    if (!activeTabDef) return null;
+    const locked = activeTabDef.premium === true && !isPremium;
+    if (!locked) {
+      return activeTabDef.content;
+    }
+    if (typeof lockedContent === 'function') {
+      return lockedContent(activeTabDef);
+    }
+    if (lockedContent !== undefined) {
+      return lockedContent;
+    }
+    return (
+      <p className="rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface-raised)] p-6 text-center text-sm text-[var(--ui-text-secondary)]">
+        Esta sección es Premium.
+      </p>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col gap-4 ${className}`}>
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        className="flex gap-1 overflow-x-auto rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface-raised)] p-1"
+      >
+        {tabs.map((t) => {
+          const selected = active === t.id;
+          const gated = t.premium === true && !isPremium;
+          return (
+            <button
+              key={t.id}
+              role="tab"
+              aria-selected={selected}
+              aria-controls={`${idPrefix}-panel-${t.id}`}
+              id={`${idPrefix}-tab-${t.id}`}
+              type="button"
+              onClick={() => selectTab(t.id)}
+              className={`flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-ring-color)] ${
+                selected
+                  ? 'bg-[var(--ui-primary)] text-[var(--ui-surface)]'
+                  : 'text-[var(--ui-text-secondary)] hover:bg-[var(--ui-surface-hover)] hover:text-[var(--ui-text)]'
+              }`}
+            >
+              {t.icon && <span aria-hidden="true">{t.icon}</span>}
+              {t.label}
+              {gated && (
+                <span className="ml-0.5 text-[10px]" aria-label="Premium" title="Premium">
+                  🔒
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={`${idPrefix}-panel-${active}`}
+        aria-labelledby={`${idPrefix}-tab-${active}`}
+        className="rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4 md:p-5"
+      >
+        {renderPanel()}
+      </div>
+    </div>
+  );
+}

--- a/src/MealDetailTabs.tsx
+++ b/src/MealDetailTabs.tsx
@@ -1,4 +1,5 @@
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
+import { DetailTabs, type DetailTabDefinition } from './DetailTabs';
 import { PaywallUnified, type PaywallPricing } from './PaywallUnified';
 import { RecipeReasoningPills, type RecipeReasoningData } from './RecipeReasoningPills';
 
@@ -88,24 +89,7 @@ export interface MealDetailTabsProps {
   className?: string;
 }
 
-/* ─── Tabs catalog ───────────────────────────────────────────────────── */
-
-const tabCatalog: Array<{
-  id: MealDetailTabId;
-  label: string;
-  icon: string;
-  premium?: boolean;
-}> = [
-  { id: 'recipe', label: 'Receta', icon: '🍳' },
-  { id: 'reasoning', label: 'Por qué', icon: '✨' },
-  { id: 'alternatives', label: 'Alternativas', icon: '🔁' },
-  { id: 'hydration', label: 'Hidratación', icon: '💧', premium: true },
-  { id: 'timing', label: 'Timing', icon: '⏰', premium: true },
-  { id: 'learn', label: 'Aprende', icon: '📚' },
-  { id: 'safety', label: 'Seguridad', icon: '🛡️' },
-];
-
-/* ─── Panels ─────────────────────────────────────────────────────────── */
+/* ─── Panels (domain-specific renderers) ─────────────────────────────── */
 
 function RecipePanel({ recipe }: { recipe: MealRecipe }) {
   return (
@@ -289,7 +273,7 @@ function SafetyPanel({ items }: { items: MealSafetyNote[] }) {
   );
 }
 
-/* ─── MealDetailTabs ─────────────────────────────────────────────────── */
+/* ─── MealDetailTabs (wraps DetailTabs with nutrition catalog) ──────── */
 
 export function MealDetailTabs({
   meal,
@@ -299,104 +283,89 @@ export function MealDetailTabs({
   defaultTab = 'recipe',
   className = '',
 }: MealDetailTabsProps) {
-  const [active, setActive] = useState<MealDetailTabId>(defaultTab);
+  const tabs: DetailTabDefinition<MealDetailTabId>[] = [
+    {
+      id: 'recipe',
+      label: 'Receta',
+      icon: '🍳',
+      content: <RecipePanel recipe={meal.recipe} />,
+    },
+    {
+      id: 'reasoning',
+      label: 'Por qué',
+      icon: '✨',
+      content: <RecipeReasoningPills reasons={meal.reasoning} />,
+    },
+    {
+      id: 'alternatives',
+      label: 'Alternativas',
+      icon: '🔁',
+      content: <AlternativesPanel alternatives={meal.alternatives} />,
+    },
+    {
+      id: 'hydration',
+      label: 'Hidratación',
+      icon: '💧',
+      premium: true,
+      content: <HintsPanel items={meal.hydration ?? []} emoji="💧" />,
+    },
+    {
+      id: 'timing',
+      label: 'Timing',
+      icon: '⏰',
+      premium: true,
+      content: <HintsPanel items={meal.timing ?? []} emoji="⏰" />,
+    },
+    {
+      id: 'learn',
+      label: 'Aprende',
+      icon: '📚',
+      content: <EducationPanel items={meal.education} />,
+    },
+    {
+      id: 'safety',
+      label: 'Seguridad',
+      icon: '🛡️',
+      content: <SafetyPanel items={meal.safety} />,
+    },
+  ];
 
-  function renderPanel(): ReactNode {
-    const locked = !isPremium && (active === 'hydration' || active === 'timing');
-    if (locked) {
-      if (!paywallPricing) {
-        return (
-          <p className="rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface-raised)] p-6 text-center text-sm text-[var(--ui-text-secondary)]">
-            Esta sección es Premium. Hacete Premium para verla.
-          </p>
-        );
-      }
+  function lockedContent(tab: DetailTabDefinition<MealDetailTabId>): ReactNode {
+    if (!paywallPricing) {
       return (
-        <PaywallUnified
-          trigger={active === 'hydration' ? 'plan' : 'plan'}
-          pricing={paywallPricing}
-          onUpgrade={() => onUpgrade?.()}
-          title={
-            active === 'hydration'
-              ? 'Hidratación personalizada — Premium'
-              : 'Timing de comidas — Premium'
-          }
-          subtitle={
-            active === 'hydration'
-              ? 'Ml exactos por comida, alertas y adaptación según entrenamiento.'
-              : 'Cuándo comer cada macro según tu cronotipo y objetivo.'
-          }
-        />
+        <p className="rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface-raised)] p-6 text-center text-sm text-[var(--ui-text-secondary)]">
+          Esta sección es Premium. Hacete Premium para verla.
+        </p>
       );
     }
-
-    switch (active) {
-      case 'recipe':
-        return <RecipePanel recipe={meal.recipe} />;
-      case 'reasoning':
-        return <RecipeReasoningPills reasons={meal.reasoning} />;
-      case 'alternatives':
-        return <AlternativesPanel alternatives={meal.alternatives} />;
-      case 'hydration':
-        return <HintsPanel items={meal.hydration ?? []} emoji="💧" />;
-      case 'timing':
-        return <HintsPanel items={meal.timing ?? []} emoji="⏰" />;
-      case 'learn':
-        return <EducationPanel items={meal.education} />;
-      case 'safety':
-        return <SafetyPanel items={meal.safety} />;
-      default:
-        return null;
-    }
+    return (
+      <PaywallUnified
+        trigger="plan"
+        pricing={paywallPricing}
+        onUpgrade={() => onUpgrade?.()}
+        title={
+          tab.id === 'hydration'
+            ? 'Hidratación personalizada — Premium'
+            : 'Timing de comidas — Premium'
+        }
+        subtitle={
+          tab.id === 'hydration'
+            ? 'Ml exactos por comida, alertas y adaptación según entrenamiento.'
+            : 'Cuándo comer cada macro según tu cronotipo y objetivo.'
+        }
+      />
+    );
   }
 
   return (
-    <div className={`flex flex-col gap-4 ${className}`}>
-      {/* Tab list — horizontal scroll on mobile */}
-      <div
-        role="tablist"
-        aria-label="Detalle de la comida"
-        className="flex gap-1 overflow-x-auto rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface-raised)] p-1"
-      >
-        {tabCatalog.map((t) => {
-          const selected = active === t.id;
-          const gated = !isPremium && t.premium;
-          return (
-            <button
-              key={t.id}
-              role="tab"
-              aria-selected={selected}
-              aria-controls={`meal-panel-${t.id}`}
-              id={`meal-tab-${t.id}`}
-              type="button"
-              onClick={() => setActive(t.id)}
-              className={`flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-ring-color)] ${
-                selected
-                  ? 'bg-[var(--ui-primary)] text-[var(--ui-surface)]'
-                  : 'text-[var(--ui-text-secondary)] hover:bg-[var(--ui-surface-hover)] hover:text-[var(--ui-text)]'
-              }`}
-            >
-              <span aria-hidden="true">{t.icon}</span>
-              {t.label}
-              {gated && (
-                <span className="ml-0.5 text-[10px]" aria-label="Premium" title="Premium">
-                  🔒
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Panel */}
-      <div
-        role="tabpanel"
-        id={`meal-panel-${active}`}
-        aria-labelledby={`meal-tab-${active}`}
-        className="rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4 md:p-5"
-      >
-        {renderPanel()}
-      </div>
-    </div>
+    <DetailTabs
+      tabs={tabs}
+      defaultTab={defaultTab}
+      isPremium={isPremium}
+      lockedContent={lockedContent}
+      ariaLabel="Detalle de la comida"
+      idPrefix="meal"
+      className={className}
+    />
   );
 }

--- a/src/__tests__/DetailTabs.test.tsx
+++ b/src/__tests__/DetailTabs.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DetailTabs, type DetailTabDefinition } from '../DetailTabs';
+
+const baseTabs: DetailTabDefinition<'a' | 'b' | 'c'>[] = [
+  { id: 'a', label: 'Tab A', icon: '🅰️', content: <p>Content A</p> },
+  { id: 'b', label: 'Tab B', icon: '🅱️', content: <p>Content B</p>, premium: true },
+  { id: 'c', label: 'Tab C', content: <p>Content C</p> },
+];
+
+describe('DetailTabs', () => {
+  it('renders all tabs with labels and icons', () => {
+    render(<DetailTabs tabs={baseTabs} />);
+    expect(screen.getByRole('tab', { name: /Tab A/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Tab B/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Tab C/ })).toBeInTheDocument();
+  });
+
+  it('shows first tab content by default', () => {
+    render(<DetailTabs tabs={baseTabs} />);
+    expect(screen.getByText('Content A')).toBeInTheDocument();
+    expect(screen.queryByText('Content B')).not.toBeInTheDocument();
+  });
+
+  it('respects defaultTab', () => {
+    render(<DetailTabs tabs={baseTabs} defaultTab="c" />);
+    expect(screen.getByText('Content C')).toBeInTheDocument();
+  });
+
+  it('switches active tab on click (uncontrolled)', () => {
+    render(<DetailTabs tabs={baseTabs} isPremium />);
+    fireEvent.click(screen.getByRole('tab', { name: /Tab B/ }));
+    expect(screen.getByText('Content B')).toBeInTheDocument();
+    expect(screen.queryByText('Content A')).not.toBeInTheDocument();
+  });
+
+  it('calls onTabChange when tab clicked', () => {
+    const onTabChange = vi.fn();
+    render(<DetailTabs tabs={baseTabs} onTabChange={onTabChange} />);
+    fireEvent.click(screen.getByRole('tab', { name: /Tab C/ }));
+    expect(onTabChange).toHaveBeenCalledWith('c');
+  });
+
+  it('shows lock indicator on premium tabs when not premium', () => {
+    render(<DetailTabs tabs={baseTabs} isPremium={false} />);
+    const premiumTab = screen.getByRole('tab', { name: /Tab B/ });
+    expect(premiumTab).toHaveTextContent('🔒');
+  });
+
+  it('hides lock indicator when premium', () => {
+    render(<DetailTabs tabs={baseTabs} isPremium />);
+    const premiumTab = screen.getByRole('tab', { name: /Tab B/ });
+    expect(premiumTab).not.toHaveTextContent('🔒');
+  });
+
+  it('shows default locked content for premium tabs when not premium', () => {
+    render(<DetailTabs tabs={baseTabs} isPremium={false} defaultTab="b" />);
+    expect(screen.getByText(/Esta sección es Premium/)).toBeInTheDocument();
+    expect(screen.queryByText('Content B')).not.toBeInTheDocument();
+  });
+
+  it('shows custom lockedContent (ReactNode)', () => {
+    render(
+      <DetailTabs
+        tabs={baseTabs}
+        isPremium={false}
+        defaultTab="b"
+        lockedContent={<p>CUSTOM LOCK</p>}
+      />,
+    );
+    expect(screen.getByText('CUSTOM LOCK')).toBeInTheDocument();
+  });
+
+  it('shows custom lockedContent (function with tab arg)', () => {
+    render(
+      <DetailTabs
+        tabs={baseTabs}
+        isPremium={false}
+        defaultTab="b"
+        lockedContent={(tab) => <p>Locked: {tab.label}</p>}
+      />,
+    );
+    expect(screen.getByText(/Locked: Tab B/)).toBeInTheDocument();
+  });
+
+  it('does not gate non-premium tabs', () => {
+    render(<DetailTabs tabs={baseTabs} isPremium={false} defaultTab="a" />);
+    expect(screen.getByText('Content A')).toBeInTheDocument();
+  });
+
+  it('respects controlled activeTab prop', () => {
+    const { rerender } = render(
+      <DetailTabs tabs={baseTabs} activeTab="a" isPremium />,
+    );
+    expect(screen.getByText('Content A')).toBeInTheDocument();
+    rerender(<DetailTabs tabs={baseTabs} activeTab="c" isPremium />);
+    expect(screen.getByText('Content C')).toBeInTheDocument();
+  });
+
+  it('uses idPrefix for ARIA wiring', () => {
+    render(<DetailTabs tabs={baseTabs} idPrefix="custom" />);
+    expect(screen.getByRole('tab', { name: /Tab A/ })).toHaveAttribute('id', 'custom-tab-a');
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('id', 'custom-panel-a');
+  });
+
+  it('uses ariaLabel on tablist', () => {
+    render(<DetailTabs tabs={baseTabs} ariaLabel="My tabs" />);
+    expect(screen.getByRole('tablist')).toHaveAttribute('aria-label', 'My tabs');
+  });
+
+  it('renders nothing for empty tabs array', () => {
+    const { container } = render(<DetailTabs tabs={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,9 @@ export type {
 export { EmptyStateWithCTA } from './EmptyStateWithCTA';
 export type { EmptyStateWithCTAProps, EmptyStateCTA } from './EmptyStateWithCTA';
 
+export { DetailTabs } from './DetailTabs';
+export type { DetailTabsProps, DetailTabDefinition } from './DetailTabs';
+
 export { MealDetailTabs } from './MealDetailTabs';
 export type {
   MealDetailTabsProps,


### PR DESCRIPTION
## Summary
- Extract domain-agnostic `DetailTabs` from `MealDetailTabs` — Opción B aprobada
- Generic component accepts configurable tabs (id, label, icon, premium, content)
- `MealDetailTabs` unchanged externally, wraps `DetailTabs` internally with nutrition catalog
- 15 new tests for DetailTabs behavior (selection, gating, controlled, ARIA, custom locked content)

## Why
Per plan `b2c-redesign-restart-from-prod.md` Anexo A decision #2: the original `MealDetailTabs` hardcoded 7 nutrition-specific tabs. Making the layout + premium-gating generic lets future domains (test results, supplements, products) reuse it without copy-paste.

## Test plan
- [x] 15 new tests for DetailTabs (uncontrolled/controlled, gating, lockedContent ReactNode/function, ARIA wiring)
- [x] Existing 4 MealDetailTabs tests still pass (backward compat)
- [x] All 718 tests green
- [x] Visual identical (same Tailwind classes, same panel rendering)

## Breaking changes
None. `MealDetailTabs` API is byte-identical from consumers' POV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)