### PR TITLE
feat: add CardButton component (Decision #4 from Tier 1 audit)

### DIFF
--- a/src/CardButton.tsx
+++ b/src/CardButton.tsx
@@ -1,0 +1,49 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+
+/**
+ * `<CardButton>` — semantic button rendered as a Card.
+ *
+ * Resolves the "Card-as-button" anti-pattern (audit Decision #4):
+ * existing `<Card onClick={...}>` adds `role="button"` + `tabIndex={0}` on a
+ * `<div>`, which causes ARIA double-interactive issues when the card itself
+ * contains nested `<a>` or `<button>` children.
+ *
+ * Use `<CardButton>` whenever the WHOLE card is the interaction target.
+ * Use `<Card>` (presentational) when there's nothing clickable, or when
+ * you have nested interactive children that own the actions.
+ *
+ * Renders a native `<button>` so screen readers / keyboard users get the
+ * correct semantics for free, no manual `onKeyDown` plumbing.
+ */
+
+export interface CardButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  /** Whether to add the lift-on-hover affordance (default: true) */
+  hover?: boolean;
+  /** Whether to apply default p-6 padding (default: true) */
+  padding?: boolean;
+}
+
+export const CardButton = forwardRef<HTMLButtonElement, CardButtonProps>(
+  function CardButton(
+    { children, className = '', hover = true, padding = true, type = 'button', ...rest },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={`group block w-full text-left rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface-raised)] ${
+          padding ? 'p-6' : ''
+        } ${
+          hover
+            ? 'hover:bg-[var(--ui-surface-hover)] hover:-translate-y-0.5 transition-[transform,background-color] duration-[var(--ui-duration-normal)]'
+            : ''
+        } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-ring-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--ui-surface)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 ${className}`}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  },
+);

--- a/src/__tests__/CardButton.test.tsx
+++ b/src/__tests__/CardButton.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CardButton } from '../CardButton';
+
+describe('CardButton', () => {
+  it('renders as a native button', () => {
+    render(<CardButton>Click me</CardButton>);
+    const btn = screen.getByRole('button', { name: 'Click me' });
+    expect(btn.tagName).toBe('BUTTON');
+  });
+
+  it('defaults to type=button to avoid form submission', () => {
+    render(<CardButton>X</CardButton>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('respects an explicit type prop', () => {
+    render(<CardButton type="submit">Submit</CardButton>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
+
+  it('fires onClick on click and Enter/Space (native button behavior)', () => {
+    const onClick = vi.fn();
+    render(<CardButton onClick={onClick}>Activate</CardButton>);
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards ref', () => {
+    const ref = { current: null as HTMLButtonElement | null };
+    render(<CardButton ref={ref}>x</CardButton>);
+    expect(ref.current?.tagName).toBe('BUTTON');
+  });
+
+  it('applies disabled state', () => {
+    render(<CardButton disabled>x</CardButton>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('passes through aria-label', () => {
+    render(<CardButton aria-label="Open meal detail">Detail</CardButton>);
+    expect(screen.getByRole('button', { name: 'Open meal detail' })).toBeInTheDocument();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export { Breadcrumbs } from './Breadcrumbs';
 export { Button } from './Button';
 export type { ButtonProps } from './Button';
 export { Card } from './Card';
+export { CardButton } from './CardButton';
+export type { CardButtonProps } from './CardButton';
 export { Checkbox } from './Checkbox';
 export type { CheckboxProps } from './Checkbox';
 export { Combobox } from './Combobox';


### PR DESCRIPTION
## Summary

Resolves Tier 1 audit Decision #4 — Card-as-button vs CardButton split.

\`<Card onClick={...}>\` adds \`role=\"button\"\` + \`tabIndex={0}\` on a \`<div>\`, which causes ARIA double-interactive issues when the card contains nested \`<a>\` or \`<button>\` children (the audit flagged this on ProductCard, KpiCard, and any clickable card with internal CTAs).

## What's new

\`<CardButton>\` renders a native \`<button>\` element styled like a Card. Screen readers + keyboard users get correct semantics for free — no manual \`onKeyDown\` plumbing, no aria-disabled fallback, no role conflicts with nested interactive children.

API:
\`\`\`tsx
<CardButton onClick={open} aria-label=\"View detail\">
  <h3>Title</h3>
  <p>Description...</p>
</CardButton>
\`\`\`

Defaults that match the audit recommendations:
- \`type=\"button\"\` to avoid accidental form submissions
- \`hover\` lift on by default (toggleable)
- \`padding\` p-6 by default (toggleable)
- focus-visible ring + keyboard activation native
- disabled state works without extra aria

## Migration

**No breaking changes.** Existing \`<Card onClick={...}>\` keeps working — the audit flagged it but didn't break it. New code that wants the WHOLE card to be the interaction target should use \`CardButton\`. When the card has nested interactive children, use \`Card\` (presentational) and put \`onClick\` on the children.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 766 pass (+7 new)
- [x] Native button semantics verified (role=\"button\", type=\"button\", ref forwarding, disabled, aria-label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)