### PR TITLE
fix(I18nProvider): add querystring detection so ?lang=en URLs work

### DIFF
--- a/src/I18nProvider.tsx
+++ b/src/I18nProvider.tsx
@@ -49,9 +49,10 @@ function buildInstance(props: Required<Pick<I18nProviderProps, 'lngs' | 'default
     interpolation: { escapeValue: false }, // React already escapes
     backend: { loadPath: props.loadPath },
     detection: {
-      order: ['localStorage', 'navigator', 'htmlTag'],
+      order: ['querystring', 'localStorage', 'navigator', 'htmlTag'],
       caches: ['localStorage'],
       lookupLocalStorage: 'i18nextLng',
+      lookupQuerystring: 'lang',
     },
     react: { useSuspense: false },
   };


### PR DESCRIPTION
## Summary

- Added `'querystring'` as highest-priority detector in `I18nProvider` (was: `['localStorage', 'navigator', 'htmlTag']`, now: `['querystring', 'localStorage', 'navigator', 'htmlTag']`)
- Configured `lookupQuerystring: 'lang'` to match GUNDO URL convention (e.g. `?lang=en`)

## Why

In gundo-vida, `mi.gundo.life/?lang=en` had no effect — the detector would always fall through to navigator (`es-ES` on most consumer machines) and cache `'es'` in localStorage. EN translations in `public/locales/en/{common,landing}.json` already existed but were inaccessible without manually setting `localStorage.i18nextLng = 'en'`.

This blocked the Milan investor pitch from recording real EN screen flows (we ended up using static screenshots with Remotion scroll-pan compositions as a workaround — see [Gundo_Engine PR #68](https://github.com/jplannnou/Gundo_Engine/pull/68)).

## Behavior change

- **Before**: only localStorage/navigator/htmlTag — no URL-based language override possible.
- **After**: `?lang=en` in URL takes precedence. Backward compatible — if no querystring present, falls through to the prior chain unchanged.

## Test plan

- [x] Verified locally against gundo-vida with the patched build:
  - `localhost:5177/?lang=en` → `html_lang=en`, h1 renders ""Your nutritional plan for celiac disease"", hero copy in English, CTAs ""Start"" / ""Sign in""
  - `localhost:5177/` (no querystring) → behavior unchanged, navigator-detected ES
- [x] Existing I18nProvider tests pass (they bypass detection by passing explicit resources)
- [ ] Consumer apps (gundo-finance, gundo-radar, gundo-feedback, etc.) — no behavior change for them since none use `?lang=` URLs today

🤖 Generated with [Claude Code](https://claude.com/claude-code)