### PR TITLE
feat(plan): live-construction components for nutritional plan generation

### DIFF
--- a/src/LoadingSkeletonVariants.tsx
+++ b/src/LoadingSkeletonVariants.tsx
@@ -32,7 +32,63 @@ export function ProductCardSkeleton({ className = '', ...rest }: HTMLAttributes<
 
 /* ─── MealCardSkeleton ───────────────────────────────────────────────── */
 
-export function MealCardSkeleton({ className = '', ...rest }: HTMLAttributes<HTMLDivElement>) {
+interface MealCardSkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Layout variant — should mirror the corresponding `<MealCard variant>`
+   * so the loading state matches the eventual rendered card and doesn't
+   * cause a layout shift. Default 'horizontal' (the original behavior).
+   */
+  variant?: 'full' | 'compact' | 'horizontal';
+}
+
+export function MealCardSkeleton({
+  variant = 'horizontal',
+  className = '',
+  ...rest
+}: MealCardSkeletonProps) {
+  if (variant === 'full') {
+    return (
+      <div
+        aria-busy="true"
+        aria-label="Cargando comida"
+        className={`flex flex-col overflow-hidden rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] ${className}`}
+        {...rest}
+      >
+        <Skeleton className="aspect-[16/10] w-full" />
+        <div className="flex flex-col gap-2 p-4">
+          <Skeleton className="h-3 w-1/4" rounded="sm" />
+          <Skeleton className="h-5 w-3/4" rounded="sm" />
+          <Skeleton className="h-3 w-1/2" rounded="sm" />
+          <div className="mt-3 grid grid-cols-4 gap-2">
+            <Skeleton className="h-8" rounded="md" />
+            <Skeleton className="h-8" rounded="md" />
+            <Skeleton className="h-8" rounded="md" />
+            <Skeleton className="h-8" rounded="md" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === 'compact') {
+    return (
+      <div
+        aria-busy="true"
+        aria-label="Cargando comida"
+        className={`flex flex-col gap-2 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-3 ${className}`}
+        {...rest}
+      >
+        <Skeleton className="h-3 w-1/3" rounded="sm" />
+        <Skeleton className="h-4 w-2/3" rounded="sm" />
+        <div className="mt-1 flex gap-2">
+          <Skeleton className="h-3 w-12" rounded="full" />
+          <Skeleton className="h-3 w-12" rounded="full" />
+        </div>
+      </div>
+    );
+  }
+
+  // horizontal — original layout, preserved for backward compatibility
   return (
     <div
       aria-busy="true"

--- a/src/MacroPill.tsx
+++ b/src/MacroPill.tsx
@@ -110,8 +110,12 @@ export function MacroPill({
     : `${resolvedLabel}: ${valueText} ${resolvedUnit}`;
 
   return (
+    // role="img" + aria-label is the standard pattern for compact data pills:
+    // it gives screen readers a single accessible name ("proteína: 32 de 50 g")
+    // and prevents them from reading the visual fragments separately.
+    // Avoids role="text" which is non-standard / iOS-Safari-only.
     <span
-      role="text"
+      role="img"
       aria-label={ariaLabel}
       className={`inline-flex items-center rounded-full font-medium tabular-nums ${sizeCls} ${className}`}
       style={{

--- a/src/MacroPill.tsx
+++ b/src/MacroPill.tsx
@@ -1,0 +1,151 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export type MacroKind = 'kcal' | 'protein' | 'carbs' | 'fat' | 'fiber' | 'water' | 'sodium';
+
+export interface MacroPillProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'children'> {
+  kind: MacroKind;
+  /** Numeric value (rendered with tabular-nums). */
+  value: number;
+  /** Override the default unit (defaults: kcal/g/ml/mg). */
+  unit?: string;
+  /** Optional target — when provided, renders the value as `value / target`. */
+  target?: number;
+  /**
+   * When `target` is set, switch to a "delta" rendering style with a
+   * traffic-light hint (green: within ±10%, amber: ±10–20%, red: >20%).
+   */
+  showDelta?: boolean;
+  /** Visual size. Default 'md'. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Override the icon (defaults to a colored dot). */
+  icon?: ReactNode;
+  /** Display label (default uses the kind's canonical label). */
+  label?: string;
+}
+
+/* ─── Macro palette ──────────────────────────────────────────────────── */
+
+const MACRO_COLORS: Record<MacroKind, string> = {
+  kcal: 'var(--macro-kcal, var(--ui-text))',
+  protein: 'var(--macro-protein, var(--ui-primary))',
+  carbs: 'var(--macro-carbs, var(--ui-warning))',
+  fat: 'var(--macro-fat, var(--ui-info))',
+  fiber: 'var(--macro-fiber, var(--ui-success))',
+  water: 'var(--macro-water, var(--ui-info))',
+  sodium: 'var(--macro-sodium, var(--ui-text-secondary))',
+};
+
+const DEFAULT_LABELS: Record<MacroKind, string> = {
+  kcal: 'kcal',
+  protein: 'proteína',
+  carbs: 'carbos',
+  fat: 'grasas',
+  fiber: 'fibra',
+  water: 'agua',
+  sodium: 'sodio',
+};
+
+const DEFAULT_UNITS: Record<MacroKind, string> = {
+  kcal: '',
+  protein: 'g',
+  carbs: 'g',
+  fat: 'g',
+  fiber: 'g',
+  water: 'ml',
+  sodium: 'mg',
+};
+
+/* ─── Delta semaphore ────────────────────────────────────────────────── */
+
+function deltaColor(value: number, target: number): string {
+  if (target <= 0) return 'var(--ui-text-secondary)';
+  const ratio = Math.abs(value - target) / target;
+  if (ratio <= 0.1) return 'var(--adherence-good, var(--ui-success))';
+  if (ratio <= 0.2) return 'var(--adherence-warn, var(--ui-warning))';
+  return 'var(--adherence-low, var(--ui-error))';
+}
+
+/* ─── MacroPill ──────────────────────────────────────────────────────── */
+
+/**
+ * Compact single-macro display. Use throughout the plan UI for at-a-glance
+ * macros (meal cards, day totals, recipe detail header).
+ *
+ * For a full multi-macro grid with bars/circles use the existing
+ * `<MacrosDisplay>` component.
+ *
+ * When `target` is provided + `showDelta`, the pill renders a traffic-light
+ * color matching the validation endpoint's status (±10% ok / ±20% warn / fail).
+ */
+export function MacroPill({
+  kind,
+  value,
+  unit,
+  target,
+  showDelta = false,
+  size = 'md',
+  icon,
+  label,
+  className = '',
+  ...rest
+}: MacroPillProps) {
+  const sizeCls =
+    size === 'sm' ? 'px-2 py-0.5 text-xs gap-1' :
+    size === 'lg' ? 'px-3 py-1.5 text-base gap-2' :
+    'px-2.5 py-1 text-sm gap-1.5';
+
+  const resolvedUnit = unit ?? DEFAULT_UNITS[kind];
+  const resolvedLabel = label ?? DEFAULT_LABELS[kind];
+  const color = showDelta && typeof target === 'number'
+    ? deltaColor(value, target)
+    : MACRO_COLORS[kind];
+
+  const valueText = Number.isFinite(value) ? formatNumber(value) : '—';
+  const targetText = typeof target === 'number' && Number.isFinite(target) ? formatNumber(target) : null;
+
+  const ariaLabel = targetText
+    ? `${resolvedLabel}: ${valueText} de ${targetText} ${resolvedUnit}`
+    : `${resolvedLabel}: ${valueText} ${resolvedUnit}`;
+
+  return (
+    <span
+      role="text"
+      aria-label={ariaLabel}
+      className={`inline-flex items-center rounded-full font-medium tabular-nums ${sizeCls} ${className}`}
+      style={{
+        background: `color-mix(in oklab, ${color} 12%, transparent)`,
+        color,
+      }}
+      {...rest}
+    >
+      {icon ?? (
+        <span
+          aria-hidden="true"
+          className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{ background: color }}
+        />
+      )}
+      <span className="whitespace-nowrap">
+        {valueText}
+        {targetText && (
+          <span className="opacity-60">/{targetText}</span>
+        )}
+        {resolvedUnit && <span className="ml-0.5 opacity-70">{resolvedUnit}</span>}
+      </span>
+    </span>
+  );
+}
+
+/* ─── Helpers ────────────────────────────────────────────────────────── */
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) >= 1000) {
+    return new Intl.NumberFormat('es-ES', { maximumFractionDigits: 0 }).format(value);
+  }
+  // 1 decimal for sub-100 values, 0 otherwise
+  return Math.abs(value) < 100
+    ? new Intl.NumberFormat('es-ES', { maximumFractionDigits: 1 }).format(value)
+    : new Intl.NumberFormat('es-ES', { maximumFractionDigits: 0 }).format(value);
+}

--- a/src/PlanLoaderProgress.tsx
+++ b/src/PlanLoaderProgress.tsx
@@ -1,0 +1,164 @@
+import type { ReactNode } from 'react';
+import { PlanLoaderStep } from './PlanLoaderStep';
+import {
+  PLAN_COMPONENT_NAMES,
+  PLAN_COMPONENT_LABELS_ES,
+  PLAN_COMPONENT_LABELS_EN,
+  computeProgress,
+  type PlanComponentName,
+  type PlanComponentStatus,
+  type PlanComponentStatusMap,
+} from './PlanTypes';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export interface PlanLoaderProgressProps {
+  /**
+   * Subset of plan doc fields the backend writes during generation.
+   * Pass `plan.componentStatus`, `plan.progress`, `plan.componentErrors`.
+   */
+  componentStatus?: PlanComponentStatusMap;
+  componentErrors?: Partial<Record<PlanComponentName, string>>;
+  /** 0..1. If omitted, computed from componentStatus. */
+  progress?: number;
+  /** Locale for default labels. Override with `customLabels` for full control. */
+  locale?: 'es' | 'en';
+  /** Custom labels per component, overrides locale defaults. */
+  customLabels?: Partial<Record<PlanComponentName, string>>;
+  /**
+   * Custom data preview per completed step. Use this to render the actual
+   * data the backend produced (e.g. "12 factores detectados" once the medical
+   * profile step completes). Honest UX hinges on this.
+   */
+  dataPreviews?: Partial<Record<PlanComponentName, ReactNode>>;
+  /** Hide steps with status='pending'. Default false (show all so user sees full plan). */
+  hidePending?: boolean;
+  /** Skip rendering specific steps (intermediate phases without UI value). */
+  excludeSteps?: PlanComponentName[];
+  /** Title shown above the step list. */
+  title?: ReactNode;
+  /** Subtitle / description below the title. */
+  subtitle?: ReactNode;
+  /** Footer slot (e.g. CTA "Te avisamos por email", or estimated time). */
+  footer?: ReactNode;
+  /** Animate the in-flight step indicator. Default true. */
+  animate?: boolean;
+  className?: string;
+}
+
+/* ─── Progress bar ───────────────────────────────────────────────────── */
+
+function ProgressBar({ value, animate }: { value: number; animate: boolean }) {
+  const pct = Math.max(0, Math.min(1, value)) * 100;
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={Math.round(pct)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label="Progreso de generación del plan"
+      className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--ui-surface-hover)]"
+    >
+      <div
+        className={`h-full rounded-full bg-[var(--ui-primary)] ${animate ? 'transition-[width] duration-700 ease-out' : ''}`}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+/* ─── PlanLoaderProgress ─────────────────────────────────────────────── */
+
+/**
+ * Orchestrates the live-construction loader for nutritional plan generation.
+ *
+ * Reads `componentStatus` from the plan doc (written incrementally by the
+ * Mastra workflow checkpoint steps) and renders one row per step, with the
+ * actual data the backend produced once each step completes.
+ *
+ * Designed to replace the "fake-progress" modal that just spins for 40min.
+ * Honest UX is the point: every step shown is a real workflow phase, and
+ * once completed, the data preview slot shows the real result.
+ *
+ * Mobile-first: stack vertical, hides intermediate phases by default if
+ * `excludeSteps` is passed.
+ */
+export function PlanLoaderProgress({
+  componentStatus,
+  componentErrors,
+  progress,
+  locale = 'es',
+  customLabels,
+  dataPreviews,
+  hidePending = false,
+  excludeSteps,
+  title,
+  subtitle,
+  footer,
+  animate = true,
+  className = '',
+}: PlanLoaderProgressProps) {
+  const defaultLabels = locale === 'en' ? PLAN_COMPONENT_LABELS_EN : PLAN_COMPONENT_LABELS_ES;
+  const computedProgress = progress ?? computeProgress(componentStatus);
+  const exclude = new Set(excludeSteps ?? []);
+
+  const visibleSteps = PLAN_COMPONENT_NAMES.filter((name) => !exclude.has(name)).filter((name) => {
+    if (!hidePending) return true;
+    const s = componentStatus?.[name];
+    return s !== undefined && s !== 'pending';
+  });
+
+  return (
+    <section
+      className={`flex flex-col gap-4 rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4 sm:p-6 ${className}`}
+      aria-busy={computedProgress < 1}
+    >
+      {(title || subtitle) && (
+        <header className="flex flex-col gap-1">
+          {title && (
+            <h2 className="text-lg font-semibold text-[var(--ui-text)]">{title}</h2>
+          )}
+          {subtitle && (
+            <p className="text-sm text-[var(--ui-text-secondary)]">{subtitle}</p>
+          )}
+        </header>
+      )}
+
+      <div className="flex items-center gap-3">
+        <div className="flex-1">
+          <ProgressBar value={computedProgress} animate={animate} />
+        </div>
+        <span
+          className="shrink-0 text-xs font-semibold tabular-nums text-[var(--ui-text-secondary)]"
+          aria-hidden="true"
+        >
+          {Math.round(computedProgress * 100)}%
+        </span>
+      </div>
+
+      <ol className="flex flex-col gap-0 divide-y divide-[var(--ui-border)]/40">
+        {visibleSteps.map((name) => {
+          const status: PlanComponentStatus = componentStatus?.[name] ?? 'pending';
+          const label = customLabels?.[name] ?? defaultLabels[name];
+          return (
+            <PlanLoaderStep
+              key={name}
+              id={name}
+              title={label}
+              status={status}
+              dataPreview={dataPreviews?.[name]}
+              errorMessage={componentErrors?.[name]}
+              animate={animate}
+            />
+          );
+        })}
+      </ol>
+
+      {footer && (
+        <footer className="pt-2 border-t border-[var(--ui-border)]/40">
+          {footer}
+        </footer>
+      )}
+    </section>
+  );
+}

--- a/src/PlanLoaderStep.tsx
+++ b/src/PlanLoaderStep.tsx
@@ -1,0 +1,174 @@
+import type { ReactNode } from 'react';
+import type { PlanComponentStatus } from './PlanTypes';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export interface PlanLoaderStepProps {
+  /** Stable identifier — typically a PlanComponentName from the workflow registry. */
+  id: string;
+  /** Display label (localized by the consumer). */
+  title: string;
+  /** Current backend status for this step. */
+  status: PlanComponentStatus;
+  /**
+   * Optional rich data preview rendered once the step is completed.
+   * Use this to show the actual data the backend produced — that's the
+   * point of live construction. Example: when `medicalProfile` completes,
+   * pass `dataPreview={<span>12 factores detectados</span>}`.
+   */
+  dataPreview?: ReactNode;
+  /** Optional icon (left side). Defaults to a step status glyph. */
+  icon?: ReactNode;
+  /** Optional error message rendered when status='failed'. */
+  errorMessage?: string;
+  /** When true, animate the in-flight indicator (default true; respect reduce-motion). */
+  animate?: boolean;
+  className?: string;
+}
+
+/* ─── Status glyph (no external icon dep — pure SVG) ─────────────────── */
+
+function StatusGlyph({ status, animate }: { status: PlanComponentStatus; animate: boolean }) {
+  if (status === 'completed') {
+    return (
+      <svg
+        viewBox="0 0 20 20"
+        width="20"
+        height="20"
+        fill="none"
+        aria-hidden="true"
+        className="text-[var(--ui-success)]"
+      >
+        <circle cx="10" cy="10" r="9" fill="currentColor" fillOpacity="0.15" />
+        <path
+          d="M6 10.5l2.5 2.5L14 7"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+  if (status === 'failed') {
+    return (
+      <svg
+        viewBox="0 0 20 20"
+        width="20"
+        height="20"
+        aria-hidden="true"
+        className="text-[var(--ui-error)]"
+      >
+        <circle cx="10" cy="10" r="9" fill="currentColor" fillOpacity="0.15" />
+        <path
+          d="M7 7l6 6M13 7l-6 6"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+      </svg>
+    );
+  }
+  if (status === 'generating') {
+    return (
+      <svg
+        viewBox="0 0 20 20"
+        width="20"
+        height="20"
+        aria-hidden="true"
+        className={`text-[var(--ui-primary)] ${animate ? 'motion-safe:animate-spin' : ''}`}
+        style={{ animationDuration: '1.5s' }}
+      >
+        <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" fill="none" opacity="0.2" />
+        <path
+          d="M10 2 a8 8 0 0 1 8 8"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          fill="none"
+        />
+      </svg>
+    );
+  }
+  // pending
+  return (
+    <svg viewBox="0 0 20 20" width="20" height="20" aria-hidden="true">
+      <circle cx="10" cy="10" r="8" stroke="var(--ui-border)" strokeWidth="2" fill="none" />
+    </svg>
+  );
+}
+
+/* ─── Status label for accessibility / SR ────────────────────────────── */
+
+function statusAriaLabel(status: PlanComponentStatus, title: string): string {
+  switch (status) {
+    case 'completed': return `${title} — listo`;
+    case 'generating': return `${title} — en curso`;
+    case 'failed': return `${title} — falló`;
+    case 'pending':
+    default: return `${title} — pendiente`;
+  }
+}
+
+/* ─── PlanLoaderStep ─────────────────────────────────────────────────── */
+
+/**
+ * Single step in the live-construction plan loader.
+ *
+ * Honest UX rule: when `status='completed'` and `dataPreview` is provided,
+ * show the actual data the backend produced — that's what makes this feel
+ * like watching the plan being built, instead of a fake spinner.
+ */
+export function PlanLoaderStep({
+  id,
+  title,
+  status,
+  dataPreview,
+  icon,
+  errorMessage,
+  animate = true,
+  className = '',
+}: PlanLoaderStepProps) {
+  const showPreview = status === 'completed' && dataPreview != null;
+  const showError = status === 'failed' && (errorMessage ?? '').length > 0;
+  const isMuted = status === 'pending';
+
+  return (
+    <li
+      data-step-id={id}
+      data-step-status={status}
+      className={`flex gap-3 py-2 ${isMuted ? 'opacity-50' : 'opacity-100'} transition-opacity ${className}`}
+      aria-label={statusAriaLabel(status, title)}
+      aria-current={status === 'generating' ? 'step' : undefined}
+    >
+      <div className="shrink-0 pt-0.5">
+        {icon ?? <StatusGlyph status={status} animate={animate} />}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div
+          className={`text-sm font-medium ${
+            status === 'completed'
+              ? 'text-[var(--ui-text)]'
+              : status === 'generating'
+                ? 'text-[var(--ui-primary)]'
+                : status === 'failed'
+                  ? 'text-[var(--ui-error)]'
+                  : 'text-[var(--ui-text-secondary)]'
+          }`}
+        >
+          {title}
+        </div>
+        {showPreview && (
+          <div className="mt-0.5 text-xs text-[var(--ui-text-secondary)] leading-relaxed">
+            {dataPreview}
+          </div>
+        )}
+        {showError && (
+          <div className="mt-0.5 text-xs text-[var(--ui-error)]">
+            {errorMessage}
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/PlanStatusBadge.tsx
+++ b/src/PlanStatusBadge.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from 'react';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export type PlanStatusVariant =
+  | 'generating'
+  | 'preview'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'draft';
+
+export interface PlanStatusBadgeProps {
+  status: PlanStatusVariant;
+  /** Override the default label (e.g. localization). */
+  label?: ReactNode;
+  /** Force show animated dot when generating. Default: true for 'generating'. */
+  pulse?: boolean;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+/* ─── Default config per status ──────────────────────────────────────── */
+
+interface StatusConfig {
+  defaultLabel: string;
+  bg: string;
+  fg: string;
+  dotColor: string;
+}
+
+const STATUS_CONFIG: Record<PlanStatusVariant, StatusConfig> = {
+  generating: {
+    defaultLabel: 'Generando',
+    bg: 'bg-[var(--ui-primary-soft)]',
+    fg: 'text-[var(--ui-primary)]',
+    dotColor: 'bg-[var(--ui-primary)]',
+  },
+  preview: {
+    defaultLabel: 'Vista previa',
+    bg: 'bg-[var(--ui-info-soft)]',
+    fg: 'text-[var(--ui-info)]',
+    dotColor: 'bg-[var(--ui-info)]',
+  },
+  active: {
+    defaultLabel: 'Activo',
+    bg: 'bg-[var(--ui-success-soft)]',
+    fg: 'text-[var(--ui-success)]',
+    dotColor: 'bg-[var(--ui-success)]',
+  },
+  completed: {
+    defaultLabel: 'Completado',
+    bg: 'bg-[var(--ui-success-soft)]',
+    fg: 'text-[var(--ui-success)]',
+    dotColor: 'bg-[var(--ui-success)]',
+  },
+  failed: {
+    defaultLabel: 'Falló',
+    bg: 'bg-[var(--ui-error-soft)]',
+    fg: 'text-[var(--ui-error)]',
+    dotColor: 'bg-[var(--ui-error)]',
+  },
+  draft: {
+    defaultLabel: 'Borrador',
+    bg: 'bg-[var(--ui-surface-hover)]',
+    fg: 'text-[var(--ui-text-secondary)]',
+    dotColor: 'bg-[var(--ui-text-muted)]',
+  },
+};
+
+/* ─── PlanStatusBadge ────────────────────────────────────────────────── */
+
+/**
+ * Status pill for nutritional plans. Maps backend plan.status values to
+ * design-system colors and provides an animated dot for in-progress states.
+ *
+ * `preview` is the Camino B intermediate state — first 3 days ready while
+ * the rest of the plan continues to generate in background.
+ */
+export function PlanStatusBadge({
+  status,
+  label,
+  pulse,
+  size = 'sm',
+  className = '',
+}: PlanStatusBadgeProps) {
+  const cfg = STATUS_CONFIG[status];
+  const sizeCls = size === 'md' ? 'px-3 py-1 text-sm' : 'px-2 py-0.5 text-xs';
+  const showPulse = pulse ?? status === 'generating';
+  const displayLabel = label ?? cfg.defaultLabel;
+
+  return (
+    <span
+      role="status"
+      aria-label={typeof displayLabel === 'string' ? `Estado del plan: ${displayLabel}` : undefined}
+      className={`inline-flex items-center gap-1.5 rounded-full font-medium ${cfg.bg} ${cfg.fg} ${sizeCls} ${className}`}
+    >
+      <span className="relative inline-flex h-1.5 w-1.5">
+        {showPulse && (
+          <span
+            className={`absolute inline-flex h-full w-full rounded-full ${cfg.dotColor} opacity-75 motion-safe:animate-ping`}
+          />
+        )}
+        <span className={`relative inline-flex h-1.5 w-1.5 rounded-full ${cfg.dotColor}`} />
+      </span>
+      {displayLabel}
+    </span>
+  );
+}

--- a/src/PlanTypes.ts
+++ b/src/PlanTypes.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared plan generation registry — keep in sync with backend
+ * `mastra-nutritional-plan-ai/src/shared/infrastructure/utils/component-checkpoint.types.ts`.
+ *
+ * The frontend reads this list to render the live-construction loader before
+ * any data exists. The backend uses the same list of names to write
+ * `componentStatus.<name>` on `mastra-algorithm-nutritional-plans/{planId}`.
+ *
+ * If you add a name here, add it to the backend file too (and vice versa).
+ */
+
+/** Phases of the nutritional plan workflow. Order matches BE workflow. */
+export const PLAN_COMPONENT_NAMES = [
+  'medicalProfile',
+  'nutritionalAnalysis',
+  'mealTiming',
+  'hydrationPlan',
+  'weeklyPlan',
+  'portionGuidelines',
+  'seasonalAdaptations',
+  'varietySafety',
+  'optimizeIngredients',
+  'productSearch',
+  'recipeProductValidation',
+  'phase4Enrichments',
+  'mealReasoning',
+  'ingredientReasoning',
+  'multilingual',
+] as const;
+
+export type PlanComponentName = (typeof PLAN_COMPONENT_NAMES)[number];
+
+export type PlanComponentStatus = 'pending' | 'generating' | 'completed' | 'failed';
+
+/** Shape of `componentStatus` on the plan doc. Backend may omit unstarted entries. */
+export type PlanComponentStatusMap = Partial<Record<PlanComponentName, PlanComponentStatus>>;
+
+/** Shape of the plan doc subset relevant to the FE loader. */
+export interface PlanGenerationProgress {
+  status?: 'processing' | 'generating' | 'preview' | 'active' | 'failed' | 'completed';
+  componentStatus?: PlanComponentStatusMap;
+  componentErrors?: Partial<Record<PlanComponentName, string>>;
+  /** 0..1 (mirrors completed steps / total steps). */
+  progress?: number;
+  /** Name of the step currently in flight (or last completed). */
+  currentStep?: PlanComponentName | null;
+  startedAt?: string;
+  lastStepCompletedAt?: string;
+  totalSteps?: number;
+}
+
+/**
+ * Localizable labels for each component. Consumers may override per language,
+ * but the default Spanish set ships as a sensible fallback for the GUNDO ES-first
+ * audience.
+ */
+export const PLAN_COMPONENT_LABELS_ES: Record<PlanComponentName, string> = {
+  medicalProfile: 'Perfil clínico',
+  nutritionalAnalysis: 'Requerimiento nutricional',
+  mealTiming: 'Horarios de comidas',
+  hydrationPlan: 'Plan de hidratación',
+  weeklyPlan: 'Diseñando tus comidas',
+  portionGuidelines: 'Tamaños de porción',
+  seasonalAdaptations: 'Adaptaciones de temporada',
+  varietySafety: 'Variedad y seguridad alimentaria',
+  optimizeIngredients: 'Optimizando ingredientes',
+  productSearch: 'Buscando productos disponibles',
+  recipeProductValidation: 'Validando recetas con productos',
+  phase4Enrichments: 'Lista de compras, presupuesto y educación',
+  mealReasoning: 'Razón científica de cada plato',
+  ingredientReasoning: 'Razón científica de cada ingrediente',
+  multilingual: 'Traducción multiidioma',
+};
+
+export const PLAN_COMPONENT_LABELS_EN: Record<PlanComponentName, string> = {
+  medicalProfile: 'Medical profile',
+  nutritionalAnalysis: 'Nutritional requirements',
+  mealTiming: 'Meal schedule',
+  hydrationPlan: 'Hydration plan',
+  weeklyPlan: 'Designing your meals',
+  portionGuidelines: 'Portion sizing',
+  seasonalAdaptations: 'Seasonal adaptations',
+  varietySafety: 'Variety and food safety',
+  optimizeIngredients: 'Optimizing ingredients',
+  productSearch: 'Finding available products',
+  recipeProductValidation: 'Validating recipes with products',
+  phase4Enrichments: 'Shopping list, budget and education',
+  mealReasoning: 'Scientific reasoning per meal',
+  ingredientReasoning: 'Scientific reasoning per ingredient',
+  multilingual: 'Multilingual translation',
+};
+
+/**
+ * Compute progress (0..1) from a componentStatus map.
+ * Useful when the backend `progress` field isn't yet populated (older clients
+ * before the Camino A backend deploy).
+ */
+export function computeProgress(componentStatus: PlanComponentStatusMap | undefined): number {
+  if (!componentStatus) return 0;
+  let done = 0;
+  for (const name of PLAN_COMPONENT_NAMES) {
+    if (componentStatus[name] === 'completed') done++;
+  }
+  return done / PLAN_COMPONENT_NAMES.length;
+}
+
+/**
+ * Find the step currently in flight (or about to be in flight) given a status map.
+ * Returns the first non-'completed' step in workflow order, or null if all done.
+ */
+export function getCurrentStep(
+  componentStatus: PlanComponentStatusMap | undefined,
+): PlanComponentName | null {
+  if (!componentStatus) return PLAN_COMPONENT_NAMES[0];
+  for (const name of PLAN_COMPONENT_NAMES) {
+    const s = componentStatus[name];
+    if (s !== 'completed') return name;
+  }
+  return null;
+}

--- a/src/__tests__/MacroPill.test.tsx
+++ b/src/__tests__/MacroPill.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MacroPill } from '../MacroPill';
+
+describe('MacroPill', () => {
+  it('renders kcal without unit suffix', () => {
+    render(<MacroPill kind="kcal" value={480} />);
+    expect(screen.getByText('480')).toBeInTheDocument();
+  });
+
+  it('renders protein with g unit', () => {
+    const { container } = render(<MacroPill kind="protein" value={32} />);
+    expect(container.textContent).toContain('32');
+    expect(container.textContent).toContain('g');
+  });
+
+  it('shows value/target when target is provided', () => {
+    const { container } = render(<MacroPill kind="protein" value={132} target={130} />);
+    expect(container.textContent).toContain('132');
+    expect(container.textContent).toContain('/130');
+  });
+
+  it('provides an accessible aria-label with units', () => {
+    render(<MacroPill kind="protein" value={32} target={50} />);
+    expect(screen.getByLabelText('proteína: 32 de 50 g')).toBeInTheDocument();
+  });
+
+  it('formats large numbers without decimals', () => {
+    const { container } = render(<MacroPill kind="kcal" value={1847} />);
+    // The exact thousands separator depends on the ICU locale data available
+    // in the test environment (Node may not ship full es-ES data). What we
+    // care about is that the value is integer-formatted (no decimals shown
+    // for kcal at this scale).
+    expect(container.textContent).toMatch(/1[.,]?847/);
+    expect(container.textContent).not.toContain('1847.0');
+  });
+
+  it('renders "—" for non-finite values', () => {
+    const { container } = render(<MacroPill kind="kcal" value={Number.NaN} />);
+    expect(container.textContent).toContain('—');
+  });
+
+  it('allows custom label override', () => {
+    render(<MacroPill kind="protein" value={30} label="Prot" />);
+    expect(screen.getByLabelText('Prot: 30 g')).toBeInTheDocument();
+  });
+
+  it('allows custom unit override', () => {
+    render(<MacroPill kind="water" value={3.2} unit="L" />);
+    expect(screen.getByLabelText('agua: 3,2 L')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/PlanLoaderProgress.test.tsx
+++ b/src/__tests__/PlanLoaderProgress.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PlanLoaderProgress } from '../PlanLoaderProgress';
+import { PLAN_COMPONENT_NAMES } from '../PlanTypes';
+
+describe('PlanLoaderProgress', () => {
+  it('renders every step name by default (ES labels)', () => {
+    render(<PlanLoaderProgress componentStatus={{}} />);
+    // Spot-check a few well-known steps
+    expect(screen.getByText('Perfil clínico')).toBeInTheDocument();
+    expect(screen.getByText('Plan de hidratación')).toBeInTheDocument();
+    expect(screen.getByText('Razón científica de cada plato')).toBeInTheDocument();
+  });
+
+  it('uses English labels when locale=en', () => {
+    render(<PlanLoaderProgress componentStatus={{}} locale="en" />);
+    expect(screen.getByText('Medical profile')).toBeInTheDocument();
+    expect(screen.getByText('Hydration plan')).toBeInTheDocument();
+  });
+
+  it('renders the count of steps', () => {
+    const { container } = render(<PlanLoaderProgress componentStatus={{}} />);
+    const steps = container.querySelectorAll('[data-step-id]');
+    expect(steps.length).toBe(PLAN_COMPONENT_NAMES.length);
+  });
+
+  it('computes progress from componentStatus when progress prop is omitted', () => {
+    const { container } = render(
+      <PlanLoaderProgress
+        componentStatus={{
+          medicalProfile: 'completed',
+          nutritionalAnalysis: 'completed',
+          mealTiming: 'completed',
+        }}
+      />,
+    );
+    const bar = container.querySelector('[role="progressbar"]');
+    expect(bar).toBeTruthy();
+    // 3 of 15 completed = 20%
+    expect(bar?.getAttribute('aria-valuenow')).toBe('20');
+  });
+
+  it('honors explicit progress prop over computed value', () => {
+    const { container } = render(
+      <PlanLoaderProgress
+        componentStatus={{ medicalProfile: 'completed' }}
+        progress={0.5}
+      />,
+    );
+    const bar = container.querySelector('[role="progressbar"]');
+    expect(bar?.getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  it('renders data preview for completed steps', () => {
+    render(
+      <PlanLoaderProgress
+        componentStatus={{ medicalProfile: 'completed' }}
+        dataPreviews={{
+          medicalProfile: <span>12 factores detectados</span>,
+        }}
+      />,
+    );
+    expect(screen.getByText('12 factores detectados')).toBeInTheDocument();
+  });
+
+  it('hides pending steps when hidePending is true', () => {
+    render(
+      <PlanLoaderProgress
+        componentStatus={{ medicalProfile: 'completed' }}
+        hidePending
+      />,
+    );
+    // medicalProfile rendered
+    expect(screen.getByText('Perfil clínico')).toBeInTheDocument();
+    // hydrationPlan is pending → hidden
+    expect(screen.queryByText('Plan de hidratación')).toBeNull();
+  });
+
+  it('excludes steps listed in excludeSteps', () => {
+    render(
+      <PlanLoaderProgress
+        componentStatus={{}}
+        excludeSteps={['optimizeIngredients', 'productSearch']}
+      />,
+    );
+    expect(screen.queryByText('Optimizando ingredientes')).toBeNull();
+    expect(screen.queryByText('Buscando productos disponibles')).toBeNull();
+    // unrelated step still rendered
+    expect(screen.getByText('Perfil clínico')).toBeInTheDocument();
+  });
+
+  it('renders title and subtitle when provided', () => {
+    render(
+      <PlanLoaderProgress
+        componentStatus={{}}
+        title="Estamos construyendo tu plan"
+        subtitle="Esto tarda aproximadamente 2 minutos"
+      />,
+    );
+    expect(screen.getByText('Estamos construyendo tu plan')).toBeInTheDocument();
+    expect(screen.getByText('Esto tarda aproximadamente 2 minutos')).toBeInTheDocument();
+  });
+
+  it('sets aria-busy until progress reaches 1.0', () => {
+    const { container, rerender } = render(
+      <PlanLoaderProgress componentStatus={{}} progress={0.5} />,
+    );
+    expect(container.querySelector('[aria-busy="true"]')).toBeTruthy();
+
+    rerender(<PlanLoaderProgress componentStatus={{}} progress={1} />);
+    expect(container.querySelector('[aria-busy="false"]')).toBeTruthy();
+  });
+});

--- a/src/__tests__/PlanLoaderStep.test.tsx
+++ b/src/__tests__/PlanLoaderStep.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PlanLoaderStep } from '../PlanLoaderStep';
+
+describe('PlanLoaderStep', () => {
+  it('renders the title', () => {
+    render(<PlanLoaderStep id="medicalProfile" title="Tu perfil clínico" status="pending" />);
+    expect(screen.getByText('Tu perfil clínico')).toBeInTheDocument();
+  });
+
+  it('exposes the step status via data attribute', () => {
+    const { container } = render(
+      <PlanLoaderStep id="mealTiming" title="Horarios" status="generating" />,
+    );
+    expect(container.querySelector('[data-step-id="mealTiming"]')).toBeTruthy();
+    expect(container.querySelector('[data-step-status="generating"]')).toBeTruthy();
+  });
+
+  it('marks the in-flight step with aria-current=step', () => {
+    const { container } = render(
+      <PlanLoaderStep id="mealTiming" title="Horarios" status="generating" />,
+    );
+    expect(container.querySelector('[aria-current="step"]')).toBeTruthy();
+  });
+
+  it('does NOT mark pending steps as aria-current', () => {
+    const { container } = render(
+      <PlanLoaderStep id="medicalProfile" title="Perfil" status="pending" />,
+    );
+    expect(container.querySelector('[aria-current="step"]')).toBeFalsy();
+  });
+
+  it('renders data preview only when completed', () => {
+    const { rerender } = render(
+      <PlanLoaderStep
+        id="medicalProfile"
+        title="Perfil"
+        status="pending"
+        dataPreview={<span>12 factores</span>}
+      />,
+    );
+    expect(screen.queryByText('12 factores')).toBeNull();
+
+    rerender(
+      <PlanLoaderStep
+        id="medicalProfile"
+        title="Perfil"
+        status="completed"
+        dataPreview={<span>12 factores</span>}
+      />,
+    );
+    expect(screen.getByText('12 factores')).toBeInTheDocument();
+  });
+
+  it('renders error message when status=failed', () => {
+    render(
+      <PlanLoaderStep
+        id="weeklyPlan"
+        title="Plan semanal"
+        status="failed"
+        errorMessage="Bedrock timeout"
+      />,
+    );
+    expect(screen.getByText('Bedrock timeout')).toBeInTheDocument();
+  });
+
+  it('uses accessible status label for screen readers', () => {
+    render(<PlanLoaderStep id="x" title="Comida" status="completed" />);
+    expect(screen.getByLabelText('Comida — listo')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/PlanStatusBadge.test.tsx
+++ b/src/__tests__/PlanStatusBadge.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PlanStatusBadge } from '../PlanStatusBadge';
+
+describe('PlanStatusBadge', () => {
+  it('renders default label per status', () => {
+    const cases: Array<[Parameters<typeof PlanStatusBadge>[0]['status'], string]> = [
+      ['generating', 'Generando'],
+      ['preview', 'Vista previa'],
+      ['active', 'Activo'],
+      ['completed', 'Completado'],
+      ['failed', 'Falló'],
+      ['draft', 'Borrador'],
+    ];
+    for (const [status, expectedLabel] of cases) {
+      const { unmount } = render(<PlanStatusBadge status={status} />);
+      expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('accepts custom label override', () => {
+    render(<PlanStatusBadge status="generating" label="Cooking your plan" />);
+    expect(screen.getByText('Cooking your plan')).toBeInTheDocument();
+  });
+
+  it('exposes status via aria-label', () => {
+    render(<PlanStatusBadge status="active" />);
+    expect(screen.getByLabelText('Estado del plan: Activo')).toBeInTheDocument();
+  });
+
+  it('renders an animated dot for generating status by default', () => {
+    const { container } = render(<PlanStatusBadge status="generating" />);
+    // ping element is an extra span with animate-ping class
+    const ping = container.querySelector('[class*="animate-ping"]');
+    expect(ping).toBeTruthy();
+  });
+
+  it('omits ping animation for non-generating statuses by default', () => {
+    const { container } = render(<PlanStatusBadge status="active" />);
+    const ping = container.querySelector('[class*="animate-ping"]');
+    expect(ping).toBeFalsy();
+  });
+
+  it('forces pulse via pulse prop', () => {
+    const { container } = render(<PlanStatusBadge status="preview" pulse />);
+    const ping = container.querySelector('[class*="animate-ping"]');
+    expect(ping).toBeTruthy();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,33 @@ export type {
   RecipeReasonCategory,
 } from './RecipeReasoningPills';
 
+// ── Plan generation / live construction (Camino A) ──────────────────────
+export {
+  PLAN_COMPONENT_NAMES,
+  PLAN_COMPONENT_LABELS_ES,
+  PLAN_COMPONENT_LABELS_EN,
+  computeProgress,
+  getCurrentStep,
+} from './PlanTypes';
+export type {
+  PlanComponentName,
+  PlanComponentStatus,
+  PlanComponentStatusMap,
+  PlanGenerationProgress,
+} from './PlanTypes';
+
+export { PlanLoaderStep } from './PlanLoaderStep';
+export type { PlanLoaderStepProps } from './PlanLoaderStep';
+
+export { PlanLoaderProgress } from './PlanLoaderProgress';
+export type { PlanLoaderProgressProps } from './PlanLoaderProgress';
+
+export { PlanStatusBadge } from './PlanStatusBadge';
+export type { PlanStatusBadgeProps, PlanStatusVariant } from './PlanStatusBadge';
+
+export { MacroPill } from './MacroPill';
+export type { MacroPillProps, MacroKind } from './MacroPill';
+
 export { DataChip } from './DataChip';
 export type { DataChipProps, DataChipStatus } from './DataChip';
 


### PR DESCRIPTION
## Summary

Counterpart to the backend Camino A work in [Gundo-Health-and-Food/mastra-nutritional-plan-ai#16](https://github.com/Gundo-Health-and-Food/mastra-nutritional-plan-ai/pull/16). The backend now publishes step-by-step progress to Firestore during the ~40-min nutritional plan generation; these components let consuming apps (gundo-vida, gundo-ecommerce-ui, gundo-plataform-ui) render that progress as a live-construction loader instead of a fake-progress modal.

## New components

- **`PlanLoaderStep`** — single phase row with status pill, pure-SVG status glyph, optional `dataPreview` slot for the actual data the backend produced once the phase completes, and optional `errorMessage` when failed. `aria-current="step"` while in flight.

- **`PlanLoaderProgress`** — orchestrator that reads `componentStatus` from the plan doc and renders one `PlanLoaderStep` per phase + an overall progress bar. Supports `dataPreviews` (per-phase real-data slots), `hidePending`, `excludeSteps`, `locale='es'|'en'`, full label override via `customLabels`, optional `title`/`subtitle`/`footer` slots.

- **`PlanStatusBadge`** — pill for the plan's overall status: `generating` / `preview` / `active` / `completed` / `failed` / `draft`. Animated dot pulses for in-progress states (respects prefers-reduced-motion).

- **`MacroPill`** — compact single-macro display (kcal / protein / carbs / fat / fiber / water / sodium) with optional `target` for "value/target" rendering and `showDelta` for ±10% / ±20% / >20% traffic-light coloring driven by `--macro-*` and `--adherence-*` tokens. Falls back to `--ui-primary`/`warning`/`info` when those aren't defined in the consumer.

- **`MealCardSkeleton`** (extended) — added `variant: 'full' | 'compact' | 'horizontal'` prop, defaulting to `'horizontal'` (the original behavior — **backward compatible**). New `'full'` and `'compact'` variants match the corresponding `<MealCard>` layouts so the loading state doesn't cause layout shift when real data arrives.

## Shared registry — BE/FE alignment

`PlanTypes.ts` is the FE counterpart to the backend [`component-checkpoint.types.ts`](https://github.com/Gundo-Health-and-Food/mastra-nutritional-plan-ai/blob/feat/component-status-granular/src/shared/infrastructure/utils/component-checkpoint.types.ts). Exports:

- `PLAN_COMPONENT_NAMES` — ordered list of the 15 workflow phases
- `PLAN_COMPONENT_LABELS_ES` / `_EN` — default localized labels
- `PlanComponentStatus` / `PlanComponentStatusMap` / `PlanGenerationProgress` types
- `computeProgress(componentStatus)` — fallback when backend `progress` field isn't populated
- `getCurrentStep(componentStatus)` — first non-completed step in workflow order

Names + order must stay in sync with the backend file.

## Verification

- ✅ `pnpm run typecheck` — **0 errors**.
- ✅ `pnpm test -- --run` against only the new tests:
    - `PlanLoaderStep` ✓ 7/7
    - `PlanLoaderProgress` ✓ 10/10
    - `PlanStatusBadge` ✓ 6/6
    - `MacroPill` ✓ 8/8
    - **Total** ✓ **31/31**
- ✅ Full suite: 826 passed / 3 failed (the 3 failures are pre-existing in `ThemeToggle.test.tsx`, unrelated to this branch).

## A11y

- All new components use semantic HTML (`<section>`, `<ol>`, `<li>`, `<header>`, `<footer>`).
- `aria-busy` on the loader until progress reaches 1.0.
- `aria-current="step"` on the in-flight phase.
- `aria-label` per step ("Perfil clínico — listo" / "— en curso" / "— pendiente" / "— falló").
- ProgressBar exposes `aria-valuenow` / `aria-valuemin` / `aria-valuemax`.
- `MacroPill` `aria-label` includes value + target + unit.
- Animations respect `prefers-reduced-motion` via Tailwind's `motion-safe:` modifier.

## Design system compliance

- Zero hardcoded colors — all `var(--ui-*)` / `var(--macro-*)` / `var(--adherence-*)` tokens.
- Status-based colors mirror Badge.tsx semantics: `--ui-primary` for in-progress, `--ui-success` for completed, `--ui-error` for failed.
- Matches existing component patterns in `MealCard` / `MacrosDisplay` / `RecipeReasoningPills`.

## Test plan

- [x] `pnpm run typecheck` — clean.
- [x] `pnpm test` — all my new tests passing.
- [x] No new visual regressions (all new components).
- [x] Backward compatible — `MealCardSkeleton` defaults to `'horizontal'` variant which renders identically to the prior version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)