### PR TITLE
feat(widget): GundoWidget — floating communication hub (chat + history + feedback slot)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jplannnou/gundo-ui",
-  "version": "1.10.1",
+  "version": "1.12.0",
   "packageManager": "pnpm@10.30.1",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,25 @@ export { FadeIn } from './motion/FadeIn';
 export { useReducedMotion } from './utils/useReducedMotion';
 export { useMediaQuery, useIsMobile } from './utils/useMediaQuery';
 
+// Communication widget-hub (chat + history + feedback slot)
+export { GundoWidget } from './widget/GundoWidget';
+export type { GundoWidgetProps, GundoWidgetSection } from './widget/GundoWidget';
+export { ChatSection } from './widget/ChatSection';
+export type { ChatSectionProps, ChatLabels } from './widget/ChatSection';
+export { ChatHistorySection } from './widget/ChatHistorySection';
+export type { ChatHistorySectionProps } from './widget/ChatHistorySection';
+export { ChatClient } from './widget/chat-client';
+export type {
+  ChatClientConfig,
+  ChatHealthContext,
+  SendMessageParams,
+  ChatStreamEvent,
+  ChatHistoryMessage,
+  ChatHistoryResponse,
+  ChatProductCard,
+  FoodAnalysis,
+} from './widget/chat-client';
+
 // i18n providers + formatting (peer-dep on i18next/react-i18next)
 export { I18nProvider, DocumentLanguage } from './I18nProvider';
 export type { I18nProviderProps } from './I18nProvider';

--- a/src/widget/ChatHistorySection.tsx
+++ b/src/widget/ChatHistorySection.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import { MessageCircle, ChevronRight } from 'lucide-react';
+import { ChatClient, type ChatHistoryMessage } from './chat-client';
+
+export interface ChatHistorySectionProps {
+  client: ChatClient;
+  locale?: string;
+  /** Called when the user taps a past conversation to resume it */
+  onResume: () => void;
+  labels?: {
+    empty?: string;
+    resume?: string;
+    title?: string;
+  };
+}
+
+/**
+ * "Mis charlas" — lists past conversation turns and lets the user jump back
+ * into the live chat (which re-loads the same history). v1 shows a flat,
+ * recent-first list; threaded sessions land in v2 when the Engine exposes a
+ * session index endpoint.
+ */
+export function ChatHistorySection({ client, locale = 'es', onResume, labels }: ChatHistorySectionProps) {
+  const [messages, setMessages] = useState<ChatHistoryMessage[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    client
+      .history(50)
+      .then((h) => {
+        if (!cancelled) setMessages(h.messages);
+      })
+      .catch(() => {
+        if (!cancelled) setMessages([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  if (messages === null) {
+    return <div className="p-6 text-sm text-[var(--ui-text-muted)]">Cargando…</div>;
+  }
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+        <MessageCircle className="w-10 h-10 text-[var(--ui-text-faint)] mb-3" />
+        <p className="text-sm text-[var(--ui-text-muted)]">
+          {labels?.empty ?? 'Todavía no tenés charlas. Empezá una desde el Asistente.'}
+        </p>
+      </div>
+    );
+  }
+
+  // Group into user-turn previews (recent first): show the user message + the
+  // assistant reply preview so it reads like a conversation log.
+  const userTurns = messages.filter((m) => m.role === 'user').reverse();
+
+  return (
+    <div className="h-full overflow-y-auto p-3 space-y-2">
+      <button
+        type="button"
+        onClick={onResume}
+        className="w-full flex items-center justify-between gap-3 px-3 py-3 rounded-xl bg-[var(--ui-surface)] border border-[var(--ui-border)] hover:border-[var(--ui-primary)] transition-colors text-left"
+      >
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-[var(--ui-text)]">
+            {labels?.resume ?? 'Continuar mi conversación'}
+          </p>
+          <p className="text-xs text-[var(--ui-text-muted)]">
+            {messages.length} mensajes · último{' '}
+            {new Date(messages[messages.length - 1]?.timestamp ?? Date.now()).toLocaleDateString(locale)}
+          </p>
+        </div>
+        <ChevronRight className="w-4 h-4 text-[var(--ui-text-muted)] shrink-0" />
+      </button>
+
+      <div className="pt-1">
+        {userTurns.slice(0, 30).map((m) => (
+          <div key={m.id} className="px-3 py-2 border-b border-[var(--ui-border)] last:border-0">
+            <p className="text-sm text-[var(--ui-text)] truncate">{m.content}</p>
+            <p className="text-[11px] text-[var(--ui-text-subtle)]">
+              {new Date(m.timestamp).toLocaleString(locale, {
+                day: '2-digit',
+                month: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/widget/ChatSection.tsx
+++ b/src/widget/ChatSection.tsx
@@ -1,0 +1,464 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { Camera, FileText, Paperclip, Send } from 'lucide-react';
+import {
+  ChatClient,
+  type ChatProductCard,
+  type FoodAnalysis,
+  type ChatHealthContext,
+  type SendMessageParams,
+} from './chat-client';
+
+export interface ChatLabels {
+  online: string;
+  inputPlaceholder: string;
+  attach: string;
+  capture: string;
+  send: string;
+  sources: string;
+  errorMessage: string;
+  compatible: string;
+  notCompatible: string;
+  foodAnalysisTitle: string;
+  allergenWarning: string;
+  estimateNote: string;
+}
+
+const DEFAULT_LABELS: ChatLabels = {
+  online: 'En línea',
+  inputPlaceholder: 'Escribí tu mensaje…',
+  attach: 'Adjuntar',
+  capture: 'Tomar foto',
+  send: 'Enviar',
+  sources: 'Fuentes',
+  errorMessage: 'Disculpá, tuve un problema técnico. Probá de nuevo en un momento.',
+  compatible: 'Compatible',
+  notCompatible: 'No compatible',
+  foodAnalysisTitle: 'Análisis del plato',
+  allergenWarning: 'Alerta de alérgenos',
+  estimateNote: 'Valores estimados, no sustituyen una etiqueta nutricional.',
+};
+
+interface DisplayMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+  productCards?: ChatProductCard[];
+  foodAnalysis?: FoodAnalysis;
+  sources?: Array<{ title: string; url: string }>;
+  suggestedFollowUps?: string[];
+  disclaimer?: string;
+  media?: Array<{ type: string; name: string; preview?: string }>;
+  isStreaming?: boolean;
+}
+
+export interface ChatSectionProps {
+  client: ChatClient;
+  healthContext?: ChatHealthContext;
+  welcomeMessage?: string;
+  welcomeFollowUps?: string[];
+  labels?: Partial<ChatLabels>;
+  locale?: string;
+  /** fire-and-forget analytics hook */
+  onEvent?: (event: string, payload?: Record<string, unknown>) => void;
+}
+
+export function ChatSection({
+  client,
+  healthContext,
+  welcomeMessage = '¡Hola! Soy tu asistente de nutrición de Gundo. ¿En qué te ayudo hoy?',
+  welcomeFollowUps = [],
+  labels: labelsProp,
+  locale = 'es',
+  onEvent,
+}: ChatSectionProps) {
+  const labels = { ...DEFAULT_LABELS, ...labelsProp };
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+
+  const buildWelcome = useCallback(
+    (): DisplayMessage => ({
+      id: 'welcome',
+      role: 'assistant',
+      content: welcomeMessage,
+      timestamp: new Date().toISOString(),
+      suggestedFollowUps: welcomeFollowUps,
+    }),
+    [welcomeMessage, welcomeFollowUps],
+  );
+
+  const [messages, setMessages] = useState<DisplayMessage[]>(() => [buildWelcome()]);
+  const [input, setInput] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const [historyLoaded, setHistoryLoaded] = useState(false);
+
+  // Load history on mount
+  useEffect(() => {
+    if (historyLoaded) return;
+    client
+      .history(30)
+      .then((history) => {
+        if (history.messages.length > 0) {
+          const loaded: DisplayMessage[] = history.messages.map((m) => ({
+            id: m.id,
+            role: m.role,
+            content: m.content,
+            timestamp: m.timestamp,
+            productCards: m.productCards,
+            sources: m.sources,
+            suggestedFollowUps: m.suggestedFollowUps,
+            disclaimer: m.disclaimer,
+          }));
+          setMessages([buildWelcome(), ...loaded]);
+        }
+        setHistoryLoaded(true);
+      })
+      .catch(() => setHistoryLoaded(true));
+  }, [client, historyLoaded, buildWelcome]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // Cleanup blob URLs
+  useEffect(() => {
+    return () => {
+      messages.forEach((msg) =>
+        msg.media?.forEach((m) => {
+          if (m.preview?.startsWith('blob:')) URL.revokeObjectURL(m.preview);
+        }),
+      );
+    };
+  }, [messages]);
+
+  const handleSend = useCallback(
+    async (text: string, files?: File[]) => {
+      const trimmed = text.trim();
+      if ((!trimmed && !files?.length) || isStreaming) return;
+
+      onEvent?.('chat_message_sent', { hasMedia: !!files?.length });
+
+      const userMsg: DisplayMessage = {
+        id: `user_${Date.now()}`,
+        role: 'user',
+        content: trimmed || (files?.length ? `📎 ${files.map((f) => f.name).join(', ')}` : ''),
+        timestamp: new Date().toISOString(),
+        media: files?.map((f) => ({
+          type: f.type.startsWith('image/') ? 'image' : 'document',
+          name: f.name,
+          preview: f.type.startsWith('image/') ? URL.createObjectURL(f) : undefined,
+        })),
+      };
+      const assistantId = `assistant_${Date.now()}`;
+      const streamingMsg: DisplayMessage = {
+        id: assistantId,
+        role: 'assistant',
+        content: '',
+        timestamp: new Date().toISOString(),
+        isStreaming: true,
+      };
+
+      setMessages((prev) => [...prev, userMsg, streamingMsg]);
+      setInput('');
+      setPendingFiles([]);
+      setIsStreaming(true);
+
+      try {
+        const params: SendMessageParams = {
+          message: trimmed,
+          channel: 'app',
+          media: files,
+          ...healthContext,
+        };
+
+        let fullContent = '';
+        let productCards: ChatProductCard[] | undefined;
+        let disclaimer: string | undefined;
+        let suggestedFollowUps: string[] | undefined;
+        let foodAnalysis: FoodAnalysis | undefined;
+
+        for await (const event of client.stream(params)) {
+          switch (event.type) {
+            case 'token':
+              fullContent += event.data;
+              setMessages((prev) =>
+                prev.map((m) => (m.id === assistantId ? { ...m, content: fullContent } : m)),
+              );
+              break;
+            case 'product_cards':
+              productCards = JSON.parse(event.data);
+              break;
+            case 'food_analysis':
+              foodAnalysis = JSON.parse(event.data);
+              break;
+            case 'disclaimer':
+              disclaimer = event.data;
+              break;
+            case 'follow_ups':
+              suggestedFollowUps = JSON.parse(event.data);
+              break;
+            case 'error':
+              fullContent = event.data;
+              break;
+            case 'done':
+              break;
+          }
+        }
+
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, content: fullContent, productCards, foodAnalysis, disclaimer, suggestedFollowUps, isStreaming: false }
+              : m,
+          ),
+        );
+      } catch {
+        setMessages((prev) =>
+          prev.map((m) => (m.id === assistantId ? { ...m, content: labels.errorMessage, isStreaming: false } : m)),
+        );
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [isStreaming, healthContext, client, labels.errorMessage, onEvent],
+  );
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length) handleSend(input, files);
+    e.target.value = '';
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-[var(--ui-surface-body)]">
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-4 space-y-3 pt-3 pb-4">
+        <AnimatePresence>
+          {messages.map((msg) => (
+            <motion.div
+              key={msg.id}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2 }}
+              className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+            >
+              <div className="max-w-[88%]">
+                {msg.media?.map(
+                  (m, i) =>
+                    m.preview && (
+                      <img
+                        key={i}
+                        src={m.preview}
+                        alt={m.name}
+                        className="w-48 h-48 object-cover rounded-xl mb-2 border border-[var(--ui-border)]"
+                      />
+                    ),
+                )}
+                <div
+                  className={`rounded-2xl px-4 py-3 ${
+                    msg.role === 'user'
+                      ? 'bg-[var(--ui-primary)] text-[var(--ui-surface)] rounded-br-sm'
+                      : 'bg-[var(--ui-surface)] border border-[var(--ui-border)] text-[var(--ui-text)] rounded-bl-sm'
+                  }`}
+                >
+                  <p className="text-sm whitespace-pre-wrap leading-relaxed">{msg.content}</p>
+                  {msg.isStreaming && !msg.content && (
+                    <div className="flex gap-1.5 py-1">
+                      {[0, 150, 300].map((d) => (
+                        <div
+                          key={d}
+                          className="w-1.5 h-1.5 rounded-full bg-[var(--ui-text-muted)] animate-bounce"
+                          style={{ animationDelay: `${d}ms` }}
+                        />
+                      ))}
+                    </div>
+                  )}
+                  {msg.sources && msg.sources.length > 0 && (
+                    <div className="mt-2 pt-2 border-t border-[var(--ui-border)]">
+                      <p className="text-[10px] text-[var(--ui-text-subtle)] uppercase font-bold mb-1">{labels.sources}</p>
+                      {msg.sources.map((s, j) => (
+                        <a
+                          key={j}
+                          href={s.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-[var(--ui-primary)] hover:underline block truncate"
+                        >
+                          {s.title}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                  <span className="text-[10px] mt-1 block opacity-50">
+                    {new Date(msg.timestamp).toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                </div>
+
+                {msg.productCards?.map((p) => (
+                  <ProductCardInline key={p.ean} product={p} labels={labels} />
+                ))}
+                {msg.foodAnalysis && <FoodAnalysisCard analysis={msg.foodAnalysis} labels={labels} />}
+                {msg.disclaimer && (
+                  <p className="mt-2 text-[11px] text-[var(--ui-text-subtle)] italic px-1">{msg.disclaimer}</p>
+                )}
+                {msg.suggestedFollowUps && msg.suggestedFollowUps.length > 0 && !msg.isStreaming && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {msg.suggestedFollowUps.map((q) => (
+                      <button
+                        key={q}
+                        onClick={() => handleSend(q)}
+                        className="px-2.5 py-1 rounded-full bg-[var(--ui-surface)] border border-[var(--ui-border)] text-[11px] text-[var(--ui-text-muted)] hover:border-[var(--ui-primary)] transition-colors"
+                      >
+                        {q}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input bar */}
+      <div className="px-3 py-3 shrink-0 border-t border-[var(--ui-border)] bg-[var(--ui-surface-body)]">
+        {pendingFiles.length > 0 && (
+          <div className="flex gap-2 mb-2">
+            {pendingFiles.map((f, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-[var(--ui-surface)] border border-[var(--ui-border)] text-xs text-[var(--ui-text-muted)]"
+              >
+                {f.type.startsWith('image/') ? <Camera className="w-3.5 h-3.5" /> : <FileText className="w-3.5 h-3.5" />}
+                <span className="max-w-[100px] truncate">{f.name}</span>
+                <button onClick={() => setPendingFiles((prev) => prev.filter((_, j) => j !== i))}>✕</button>
+              </div>
+            ))}
+          </div>
+        )}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSend(input, pendingFiles.length ? pendingFiles : undefined);
+          }}
+          className="flex items-center gap-2"
+        >
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            aria-label={labels.attach}
+            className="w-10 h-10 rounded-xl bg-[var(--ui-surface)] border border-[var(--ui-border)] flex items-center justify-center text-[var(--ui-text-muted)] active:scale-95 transition-transform"
+          >
+            <Paperclip className="w-5 h-5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => cameraInputRef.current?.click()}
+            aria-label={labels.capture}
+            className="w-10 h-10 rounded-xl bg-[var(--ui-surface)] border border-[var(--ui-border)] flex items-center justify-center text-[var(--ui-text-muted)] active:scale-95 transition-transform"
+          >
+            <Camera className="w-5 h-5" />
+          </button>
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={labels.inputPlaceholder}
+            disabled={isStreaming}
+            className="flex-1 px-3 py-2.5 rounded-xl bg-[var(--ui-surface)] border border-[var(--ui-border)] text-[var(--ui-text)] text-sm placeholder:text-[var(--ui-text-subtle)] focus:ring-2 focus:ring-[var(--ui-primary)] outline-none disabled:opacity-50"
+          />
+          <button
+            type="submit"
+            aria-label={labels.send}
+            disabled={(!input.trim() && !pendingFiles.length) || isStreaming}
+            className="w-10 h-10 rounded-xl bg-[var(--ui-primary)] text-[var(--ui-surface)] flex items-center justify-center disabled:opacity-30 active:scale-95 transition-transform"
+          >
+            <Send className="w-4 h-4" />
+          </button>
+        </form>
+        <input ref={fileInputRef} type="file" accept=".pdf,image/*" multiple className="hidden" onChange={handleFileSelect} />
+        <input
+          ref={cameraInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          className="hidden"
+          onChange={handleFileSelect}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ProductCardInline({ product, labels }: { product: ChatProductCard; labels: ChatLabels }) {
+  const score = product.compatibilityScore ?? 0;
+  const color = score >= 70 ? 'text-green-400' : score >= 40 ? 'text-yellow-400' : 'text-red-400';
+  const barColor = score >= 70 ? 'bg-green-400' : score >= 40 ? 'bg-yellow-400' : 'bg-red-400';
+  return (
+    <div className="mt-2 bg-[var(--ui-surface)] border border-[var(--ui-border)] rounded-xl p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-[var(--ui-text)] truncate">{product.name}</p>
+          {product.brand && <p className="text-xs text-[var(--ui-text-subtle)]">{product.brand}</p>}
+        </div>
+        <div className="text-right shrink-0">
+          <span className={`text-lg font-bold ${color}`}>{score}</span>
+          <span className="text-[10px] text-[var(--ui-text-subtle)]">/100</span>
+        </div>
+      </div>
+      <div className="mt-2 h-1.5 rounded-full bg-black/10 overflow-hidden">
+        <div className={`h-full rounded-full ${barColor}`} style={{ width: `${score}%` }} />
+      </div>
+      <div className="mt-2 flex items-center gap-2 text-[11px]">
+        <span
+          className={`px-1.5 py-0.5 rounded ${
+            product.compatible ? 'bg-green-400/10 text-green-400' : 'bg-red-400/10 text-red-400'
+          }`}
+        >
+          {product.compatible ? labels.compatible : labels.notCompatible}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function FoodAnalysisCard({ analysis, labels }: { analysis: FoodAnalysis; labels: ChatLabels }) {
+  const score = analysis.compatibilityScore;
+  const color = score >= 70 ? 'text-green-400' : score >= 40 ? 'text-yellow-400' : 'text-red-400';
+  return (
+    <div className="mt-2 bg-[var(--ui-surface)] border border-[var(--ui-border)] rounded-xl p-3">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-bold text-[var(--ui-text)] uppercase tracking-wider">{labels.foodAnalysisTitle}</p>
+        <span className={`text-lg font-bold ${color}`}>{score}/100</span>
+      </div>
+      <div className="grid grid-cols-4 gap-2 mb-2">
+        {[
+          { label: 'kcal', value: analysis.nutritionalInfo.kcal },
+          { label: 'Prot', value: `${analysis.nutritionalInfo.proteins}g` },
+          { label: 'Carb', value: `${analysis.nutritionalInfo.carbs}g` },
+          { label: 'Gras', value: `${analysis.nutritionalInfo.fats}g` },
+        ].map((m) => (
+          <div key={m.label} className="text-center">
+            <p className="text-sm font-bold text-[var(--ui-text)]">{m.value}</p>
+            <p className="text-[10px] text-[var(--ui-text-subtle)]">{m.label}</p>
+          </div>
+        ))}
+      </div>
+      {analysis.allergenWarnings.length > 0 && (
+        <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/20">
+          <p className="text-xs text-red-400 font-bold">{labels.allergenWarning}</p>
+          {analysis.allergenWarnings.map((w, i) => (
+            <p key={i} className="text-xs text-red-300">
+              {w}
+            </p>
+          ))}
+        </div>
+      )}
+      <p className="mt-2 text-[10px] text-[var(--ui-text-faint)] italic">{labels.estimateNote}</p>
+    </div>
+  );
+}

--- a/src/widget/GundoWidget.tsx
+++ b/src/widget/GundoWidget.tsx
@@ -1,0 +1,181 @@
+import { useState, type ReactNode } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { MessageCircle, X, Clock, MessageSquarePlus } from 'lucide-react';
+import { ChatClient, type ChatClientConfig, type ChatHealthContext } from './chat-client';
+import { ChatSection, type ChatLabels } from './ChatSection';
+import { ChatHistorySection } from './ChatHistorySection';
+
+export type GundoWidgetSection = 'chat' | 'history' | 'feedback';
+
+export interface GundoWidgetProps {
+  /** Engine base URL + token resolver + logical product */
+  api: ChatClientConfig;
+  /** Health/profile context passed to the bot for personalization */
+  healthContext?: ChatHealthContext;
+  /** Welcome bubble copy + starter chips */
+  welcomeMessage?: string;
+  welcomeFollowUps?: string[];
+  /** Override any chat label (defaults are Spanish) */
+  chatLabels?: Partial<ChatLabels>;
+  locale?: string;
+  /** Product name shown in the panel header */
+  productName?: string;
+  /**
+   * Feedback UI for the "Feedback" tab. The host passes its
+   * `@gundo/feedback-sdk` component here so the widget stays decoupled from
+   * the SDK (no dependency in @gundo/ui). If omitted, the Feedback tab is
+   * hidden.
+   */
+  feedbackSlot?: ReactNode;
+  /** Badge count on the floating bubble (unread / novedades) — v2+ */
+  badgeCount?: number;
+  /** fire-and-forget analytics hook */
+  onEvent?: (event: string, payload?: Record<string, unknown>) => void;
+  /** start open (default false) */
+  defaultOpen?: boolean;
+}
+
+const TAB_LABELS: Record<GundoWidgetSection, string> = {
+  chat: 'Asistente',
+  history: 'Mis charlas',
+  feedback: 'Feedback',
+};
+
+/**
+ * GundoWidget — floating communication hub. One bubble, one panel, several
+ * sections: Asistente (chat with the Engine bot), Mis charlas (conversation
+ * history + resume), Feedback (host-provided slot, usually @gundo/feedback-sdk).
+ *
+ * Replaces the standalone FeedbackToggle so there's a single floating entry
+ * point per product. Designed to be embedded once per app (global provider)
+ * and reused across Vida / ultrapersonalización / datacenter.
+ */
+export function GundoWidget({
+  api,
+  healthContext,
+  welcomeMessage,
+  welcomeFollowUps,
+  chatLabels,
+  locale = 'es',
+  productName = 'Gundo',
+  feedbackSlot,
+  badgeCount = 0,
+  onEvent,
+  defaultOpen = false,
+}: GundoWidgetProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [section, setSection] = useState<GundoWidgetSection>('chat');
+  const [client] = useState(() => new ChatClient(api));
+  const [resumeSessionId, setResumeSessionId] = useState<string | null>(null);
+
+  const sections: GundoWidgetSection[] = feedbackSlot
+    ? ['chat', 'history', 'feedback']
+    : ['chat', 'history'];
+
+  const toggle = () => {
+    setOpen((o) => {
+      const next = !o;
+      onEvent?.(next ? 'widget_opened' : 'widget_closed', { section });
+      return next;
+    });
+  };
+
+  return (
+    <>
+      {/* Floating bubble */}
+      <button
+        type="button"
+        onClick={toggle}
+        aria-label={open ? 'Cerrar' : `Abrir ${productName}`}
+        className="fixed bottom-5 right-5 z-[9998] w-14 h-14 rounded-full bg-[var(--ui-primary)] text-[var(--ui-surface)] shadow-lg flex items-center justify-center active:scale-95 transition-transform"
+      >
+        {open ? <X className="w-6 h-6" /> : <MessageCircle className="w-6 h-6" />}
+        {!open && badgeCount > 0 && (
+          <span className="absolute -top-1 -right-1 min-w-5 h-5 px-1 rounded-full bg-red-500 text-white text-[11px] font-bold flex items-center justify-center">
+            {badgeCount > 9 ? '9+' : badgeCount}
+          </span>
+        )}
+      </button>
+
+      {/* Panel */}
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: 24, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 24, scale: 0.96 }}
+            transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+            className="fixed bottom-24 right-5 z-[9998] w-[min(400px,calc(100vw-2.5rem))] h-[min(620px,calc(100vh-8rem))] rounded-2xl overflow-hidden border border-[var(--ui-border)] bg-[var(--ui-surface-body)] shadow-2xl flex flex-col"
+            role="dialog"
+            aria-label={productName}
+          >
+            {/* Header */}
+            <div className="px-4 pt-3 pb-2 shrink-0 border-b border-[var(--ui-border)] bg-[var(--ui-surface)]">
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+                  <span className="text-sm font-bold text-[var(--ui-text)]">{productName}</span>
+                </div>
+                <button onClick={toggle} aria-label="Cerrar" className="text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              {/* Tabs */}
+              <div className="flex gap-1">
+                {sections.map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => {
+                      setSection(s);
+                      onEvent?.('widget_section_changed', { section: s });
+                    }}
+                    className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                      section === s
+                        ? 'bg-[var(--ui-primary)] text-[var(--ui-surface)]'
+                        : 'text-[var(--ui-text-muted)] hover:bg-[var(--ui-surface-hover)]'
+                    }`}
+                  >
+                    {s === 'chat' && <MessageCircle className="w-3.5 h-3.5" />}
+                    {s === 'history' && <Clock className="w-3.5 h-3.5" />}
+                    {s === 'feedback' && <MessageSquarePlus className="w-3.5 h-3.5" />}
+                    {TAB_LABELS[s]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Body */}
+            <div className="flex-1 min-h-0">
+              {section === 'chat' && (
+                <ChatSection
+                  key={resumeSessionId ?? 'live'}
+                  client={client}
+                  healthContext={healthContext}
+                  welcomeMessage={welcomeMessage}
+                  welcomeFollowUps={welcomeFollowUps}
+                  labels={chatLabels}
+                  locale={locale}
+                  onEvent={onEvent}
+                />
+              )}
+              {section === 'history' && (
+                <ChatHistorySection
+                  client={client}
+                  locale={locale}
+                  onResume={() => {
+                    // Resuming just re-mounts the chat (history is loaded there).
+                    setResumeSessionId(`resume_${Date.now()}`);
+                    setSection('chat');
+                  }}
+                />
+              )}
+              {section === 'feedback' && feedbackSlot && (
+                <div className="h-full overflow-y-auto p-4">{feedbackSlot}</div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/widget/chat-client.ts
+++ b/src/widget/chat-client.ts
@@ -1,0 +1,179 @@
+/**
+ * Chat client for the GundoWidget — talks to the Gundo Engine `/api/chat/*`
+ * endpoints. Fully decoupled from any product: the host injects `apiBaseUrl`
+ * and a `getToken()` resolver (Firebase ID token), so the same client works
+ * from Vida, ultrapersonalización and datacenter.
+ *
+ * Ported from gundo-vida `src/api/chat.api.ts` (the original lived inside the
+ * Vida product and hardcoded its own Firebase). Behaviour is identical; only
+ * the auth + base URL are now parameters.
+ */
+
+export interface ChatProductCard {
+  ean: string;
+  name: string;
+  brand?: string;
+  novaGroup?: number;
+  compatibilityScore?: number;
+  healthRanking?: number;
+  compatible: boolean;
+  nutritionalInfo?: {
+    kcal?: number;
+    proteins?: number;
+    carbs?: number;
+    fats?: number;
+  };
+}
+
+export interface FoodAnalysis {
+  ingredients: Array<{ name: string; confidence: number }>;
+  nutritionalInfo: { kcal: number; proteins: number; carbs: number; fats: number; fiber?: number };
+  compatibilityScore: number;
+  compatibilityNotes: string[];
+  allergenWarnings: string[];
+}
+
+export interface ChatHistoryMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+  productCards?: ChatProductCard[];
+  sources?: Array<{ title: string; url: string }>;
+  suggestedFollowUps?: string[];
+  disclaimer?: string;
+  media?: Array<{ type: string; mimeType: string; size: number }>;
+}
+
+export interface ChatHistoryResponse {
+  session: { id: string; createdAt: string; messageCount: number } | null;
+  messages: ChatHistoryMessage[];
+}
+
+export interface ChatStreamEvent {
+  type: 'token' | 'product_cards' | 'food_analysis' | 'disclaimer' | 'follow_ups' | 'done' | 'error';
+  data: string;
+  metadata?: {
+    tokensUsed: { input: number; output: number; cached: number };
+    durationMs: number;
+  };
+}
+
+/**
+ * Health/profile context the host passes so the bot can personalize. All
+ * fields optional — a product without health data (or before the user
+ * completed onboarding) just sends what it has.
+ */
+export interface ChatHealthContext {
+  tier?: 'free' | 'pro';
+  conditions?: string[];
+  allergies?: string[];
+  objective?: string;
+  sex?: string;
+  age?: number;
+  medications?: string[];
+  activePlanSummary?: string;
+}
+
+export interface SendMessageParams extends ChatHealthContext {
+  message: string;
+  channel?: 'app' | 'whatsapp';
+  media?: File[];
+}
+
+export interface ChatClientConfig {
+  apiBaseUrl: string;
+  getToken: () => Promise<string | null>;
+  /** Logical product the conversation belongs to (session key on the Engine) */
+  project?: string;
+}
+
+export class ChatClient {
+  constructor(private readonly config: ChatClientConfig) {}
+
+  private async headers(): Promise<Record<string, string>> {
+    const token = await this.config.getToken();
+    return {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(this.config.project ? { 'X-Gundo-Project': this.config.project } : {}),
+    };
+  }
+
+  private buildFormData(params: SendMessageParams): FormData {
+    const fd = new FormData();
+    fd.append('message', params.message);
+    if (params.channel) fd.append('channel', params.channel);
+    if (params.tier) fd.append('tier', params.tier);
+    if (params.conditions?.length) params.conditions.forEach((c) => fd.append('conditions', c));
+    if (params.allergies?.length) params.allergies.forEach((a) => fd.append('allergies', a));
+    if (params.objective) fd.append('objective', params.objective);
+    if (params.sex) fd.append('sex', params.sex);
+    if (params.age) fd.append('age', String(params.age));
+    if (params.medications?.length) params.medications.forEach((m) => fd.append('medications', m));
+    if (params.activePlanSummary) fd.append('activePlanSummary', params.activePlanSummary);
+    if (params.media?.length) params.media.forEach((file) => fd.append('media', file));
+    return fd;
+  }
+
+  /** Stream a message via SSE. Yields events as they arrive. */
+  async *stream(params: SendMessageParams): AsyncGenerator<ChatStreamEvent> {
+    const headers = await this.headers();
+    const response = await fetch(`${this.config.apiBaseUrl}/api/chat/stream`, {
+      method: 'POST',
+      headers, // no Content-Type — browser sets the multipart boundary
+      body: this.buildFormData(params),
+    });
+
+    if (!response.ok || !response.body) {
+      yield { type: 'error', data: 'No pude conectar con el asistente. Intentá de nuevo en unos momentos.' };
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        try {
+          yield JSON.parse(line.slice(6)) as ChatStreamEvent;
+        } catch {
+          // skip malformed SSE line
+        }
+      }
+    }
+  }
+
+  async history(limit = 50): Promise<ChatHistoryResponse> {
+    const headers = await this.headers();
+    const response = await fetch(`${this.config.apiBaseUrl}/api/chat/history?limit=${limit}`, {
+      headers: { ...headers, 'Content-Type': 'application/json' },
+    });
+    if (!response.ok) return { session: null, messages: [] };
+    return response.json();
+  }
+
+  async disclaimer(): Promise<string> {
+    const headers = await this.headers();
+    const response = await fetch(`${this.config.apiBaseUrl}/api/chat/disclaimer`, {
+      headers: { ...headers, 'Content-Type': 'application/json' },
+    });
+    if (!response.ok) return '';
+    const data = await response.json();
+    return data.disclaimer ?? '';
+  }
+
+  async deleteHistory(): Promise<void> {
+    const headers = await this.headers();
+    await fetch(`${this.config.apiBaseUrl}/api/chat/history`, {
+      method: 'DELETE',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+    });
+  }
+}


### PR DESCRIPTION
## Resumen
PR 1 del plan omnicanal ([PLAN_CHATBOT_OMNICANAL_2026-05-27](https://github.com/jplannnou/Gundo_Engine/blob/main/PLAN_CHATBOT_OMNICANAL_2026-05-27.md)). El shell del widget-hub reusable: una burbuja flotante + panel con tabs (Asistente / Mis charlas / Feedback), pensado para los 3 productos.

## Qué incluye (`src/widget/`)
- **GundoWidget** — shell: burbuja flotante (con slot de badge para novedades v2) + panel animado + tabs
- **ChatSection** — el asistente, portado del ChatPage de Vida pero desacoplado: SSE streaming, product cards, food analysis, fuentes, follow-ups, disclaimer, adjuntar imagen/doc, carga de historial. Strings vía prop `labels` (defaults ES), sin dependencia dura de react-i18next
- **ChatHistorySection** — "Mis charlas": turnos pasados + retomar
- **ChatClient** — cliente desacoplado de `/api/chat/*`. El host inyecta `apiBaseUrl` + `getToken()` + `project`. Manda header `X-Gundo-Project` para el session key por producto (Engine PR siguiente)

## Decisiones de desacople
- **Feedback = `feedbackSlot` (ReactNode), NO dependencia.** @gundo/ui no depende del feedback-sdk; cada producto pasa su componente. Tab oculta si no hay slot → no sobreposiciones.
- **healthContext** lo pasa el host desde su estado (Redux en ecommerce, profile API en Vida).
- Colores vía tokens `--ui-*` → temea por producto solo.

## Notas
- Tipo del chat renombrado a `ChatProductCard` para no chocar con el componente `ProductCard` existente de @gundo/ui.
- Bump a **1.12.0** (por delante del 1.11.0-lab.0 de ultraperso).

## Test plan
- [x] `pnpm build` + `pnpm typecheck` verdes
- [ ] CI
- [ ] PR2: migrar Vida ChatPage + FeedbackToggle al widget (regression web↔WhatsApp)
- [ ] Visual QA del widget en algún consumidor antes de que Facu lo pula

🤖 Generated with [Claude Code](https://claude.com/claude-code)