### PR TITLE
fix(widget): data-gundo-widget hook + focus trap excludes tabIndex=-1

### DIFF
--- a/src/widget/GundoWidget.tsx
+++ b/src/widget/GundoWidget.tsx
@@ -69,7 +69,7 @@ export function GundoWidget({
         panelRef.current!.querySelectorAll<HTMLElement>(
           'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
         ),
-      ).filter((el) => !el.hasAttribute('aria-hidden'));
+      ).filter((el) => !el.hasAttribute('aria-hidden') && el.tabIndex !== -1);
 
     const first = focusables()[0];
     first?.focus();
@@ -157,6 +157,7 @@ export function GundoWidget({
             aria-modal="true"
             aria-label={productName}
             lang={locale}
+            data-gundo-widget="panel"
           >
             <div className="px-4 pt-3 pb-2 shrink-0 border-b border-[var(--ui-border)] bg-[var(--ui-surface)]">
               <div className="flex items-center justify-between mb-2">


### PR DESCRIPTION
## Summary
Two minor fixes surfaced during the post-1.11.1 ultraperso re-audit.

- **\`data-gundo-widget=\"panel\"\`** on the dialog so host apps can scope theme overrides to the chat panel without touching the host's theme behavior. Ultraperso runs \`theme-light\` and the panel was rendering as a light card over a light page (low contrast). Hosts can now do \`[data-gundo-widget=\"panel\"] { --ui-surface: #292E37; ... }\` to force dark.
- **Focus trap fix**: \`focusables()\` now excludes \`tabIndex=-1\` elements explicitly. The audit found Tab cycle broke after 13 tabs across 11 focusable elements because inactive tabs (rendered with \`tabIndex=-1\` per WAI-ARIA pattern) were included via the broad \`button:not([disabled])\` selector.

## Test plan
- [ ] \`pnpm typecheck\` (✓ done locally)
- [ ] CI Visual & A11y tests
- [ ] Re-run ultraperso staging Playwright audit and verify focus stays inside dialog through ≥20 Tab presses

🤖 Generated with [Claude Code](https://claude.com/claude-code)