### PR TITLE
fix(widget+ci): focus restore on close + auto-propagate pnpm version detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,9 +117,24 @@ jobs:
           repository: ${{ matrix.repo }}
           token: ${{ secrets.RENOVATE_PAT }}
 
+      # Read consumer's pinned pnpm version. Each repo pins a specific
+      # pnpm in its `packageManager` field; running a different version
+      # mutates pnpm-lock.yaml in ways the consumer's CI rejects on the
+      # follow-up PR (e.g. gundo-plataform-ui pins 10.11.0, this workflow
+      # used to hardcode 10.30.1 → propagate PRs auto-failed CI).
+      # Fallback to 10.30.1 if the field is missing (most repos have it).
+      - name: Detect consumer pnpm version
+        id: pnpm-version
+        run: |
+          PKG="package.json"
+          if [ "${{ matrix.pkg_dir }}" != "." ]; then PKG="${{ matrix.pkg_dir }}/package.json"; fi
+          VER=$(node -p "(require('./'+'$PKG').packageManager || 'pnpm@10.30.1').replace(/^pnpm@/,'').split('+')[0]" 2>/dev/null || echo "10.30.1")
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "Using pnpm $VER for ${{ matrix.repo }}"
+
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.30.1
+          version: ${{ steps.pnpm-version.outputs.version }}
 
       - uses: actions/setup-node@v4
         with:

--- a/src/widget/GundoWidget.tsx
+++ b/src/widget/GundoWidget.tsx
@@ -61,7 +61,20 @@ export function GundoWidget({
     });
   };
 
-  // Focus trap + Esc + initial focus + focus restore on close
+  // Focus restore: when the panel closes (regardless of reason — Esc,
+  // bubble re-click, X button), put focus back on the bubble so keyboard
+  // users don't end up at the start of the document. The trap below only
+  // restored on Esc; clicking the X inside the panel left focus on a
+  // node that just unmounted.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (wasOpenRef.current && !open) {
+      bubbleRef.current?.focus();
+    }
+    wasOpenRef.current = open;
+  }, [open]);
+
+  // Focus trap + Esc + initial focus
   useEffect(() => {
     if (!open || !panelRef.current) return;
     const focusables = () =>


### PR DESCRIPTION
## Two unrelated infra cleanups

### 1. GundoWidget focus restore on close

The focus trap inside the open-effect only restored focus to the bubble when the panel was closed via **Esc**. Clicking the X button inside the panel (or re-clicking the bubble while open) left focus on a node that just unmounted, dropping keyboard users back at the top of the document.

New effect watches \`open\` and restores focus to the bubble on any true→false transition. ~10 LoC, no behavior change for non-keyboard users.

### 2. publish.yml propagate job — detect consumer pnpm version

The job hardcoded \`pnpm@10.30.1\`. But \`gundo-plataform-ui\` pins \`pnpm@10.11.0\` in its \`packageManager\` field. Running the wrong pnpm mutated \`pnpm-lock.yaml\` in ways the consumer's CI rejected → every propagate PR to that repo auto-failed CI.

Now reads \`packageManager\` from the consumer's \`package.json\` and uses that exact version (fallback to \`10.30.1\` if missing). No matrix maintenance — adding a new consumer with any pnpm version just works.

## Test plan

- [ ] CI green
- [ ] Next gundo-ui release auto-propagates to all 10 consumers including gundo-plataform-ui without lockfile-incompatibility errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)