### PR TITLE
fix(ci): auto-propagate — empty version when consumer has packageManager

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,20 +117,28 @@ jobs:
           repository: ${{ matrix.repo }}
           token: ${{ secrets.RENOVATE_PAT }}
 
-      # Read consumer's pinned pnpm version. Each repo pins a specific
-      # pnpm in its `packageManager` field; running a different version
-      # mutates pnpm-lock.yaml in ways the consumer's CI rejects on the
-      # follow-up PR (e.g. gundo-plataform-ui pins 10.11.0, this workflow
-      # used to hardcode 10.30.1 → propagate PRs auto-failed CI).
-      # Fallback to 10.30.1 if the field is missing (most repos have it).
-      - name: Detect consumer pnpm version
+      # pnpm/action-setup@v4 errors out with "Multiple versions of pnpm
+      # specified" if both the action `version` input AND the consumer's
+      # `packageManager` field are set — even when they're identical
+      # values. To respect each consumer's pinned pnpm without conflict:
+      #   - If `packageManager` is set in the consumer's package.json,
+      #     pass empty version → action auto-reads packageManager.
+      #   - If absent (legacy consumers), fall back to 10.30.1.
+      # Replaces the hardcoded 10.30.1 that broke gundo-plataform-ui
+      # (pins 10.11.0) and the 1st attempt that hit the conflict above.
+      - name: Resolve pnpm version source
         id: pnpm-version
         run: |
           PKG="package.json"
           if [ "${{ matrix.pkg_dir }}" != "." ]; then PKG="${{ matrix.pkg_dir }}/package.json"; fi
-          VER=$(node -p "(require('./'+'$PKG').packageManager || 'pnpm@10.30.1').replace(/^pnpm@/,'').split('+')[0]" 2>/dev/null || echo "10.30.1")
-          echo "version=$VER" >> "$GITHUB_OUTPUT"
-          echo "Using pnpm $VER for ${{ matrix.repo }}"
+          HAS_PM=$(node -p "!!require('./'+'$PKG').packageManager" 2>/dev/null || echo "false")
+          if [ "$HAS_PM" = "true" ]; then
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "Source: packageManager field in $PKG (auto-detect)"
+          else
+            echo "version=10.30.1" >> "$GITHUB_OUTPUT"
+            echo "Source: workflow fallback (no packageManager in $PKG)"
+          fi
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Why

PR #22 (2026-05-28) tried to fix the auto-propagate pnpm version mismatch by passing the consumer's pinned version explicitly to \`pnpm/action-setup@v4\`. But the action errors out when BOTH the \`version\` input AND \`packageManager\` field are set — even when identical:

\`\`\`
ERR_PNPM_BAD_PM_VERSION: Multiple versions of pnpm specified:
  - version 10.11.0 in the GitHub Action config with the key "version"
  - version pnpm@10.11.0+sha512... in the package.json with the key "packageManager"
\`\`\`

Broke propagate for **gundo-plataform-ui** + **gundo-admin-fitness-ui** (both pin \`pnpm@10.11.0\` in packageManager) in the v1.11.3 release.

## What changed

Conditional: if the consumer has \`packageManager\`, pass empty \`version\` → action auto-reads. Otherwise fall back to 10.30.1.

## Test plan

- [ ] CI green
- [ ] Merge → triggers new gundo-ui release (semantic-release sees the \`fix:\` commit)
- [ ] Propagate succeeds for ALL 10 consumers including the two that failed last release

🤖 Generated with [Claude Code](https://claude.com/claude-code)