### PR TITLE
fix(e2e): point finance smoke at real deploy target (gundo-finance-app)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,7 +47,10 @@ export default defineConfig({
       testMatch: 'smoke.spec.ts',
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: 'https://gundo-finance.web.app',
+        // The deploy target is the `gundo-finance-app` Hosting site, not the
+        // orphaned project-default `gundo-finance.web.app` (which serves a stale
+        // bundle and is never updated by deploys).
+        baseURL: 'https://gundo-finance-app.web.app',
       },
     },
     {


### PR DESCRIPTION
El smoke de finance apuntaba a `gundo-finance.web.app` — el site default huérfano del proyecto que sirve un bundle stale y nunca lo actualiza el deploy. El target real es el site `gundo-finance-app`. Lo apunto ahí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)