### PR TITLE
feat(ChatMarkdown): autolink bare URLs + export from root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,6 +274,7 @@ export { ChatSection } from './widget/ChatSection';
 export type { ChatSectionProps, ChatLabels } from './widget/ChatSection';
 export { ChatHistorySection } from './widget/ChatHistorySection';
 export type { ChatHistorySectionProps } from './widget/ChatHistorySection';
+export { ChatMarkdown } from './widget/ChatMarkdown';
 export { ChatClient } from './widget/chat-client';
 export type {
   ChatClientConfig,

--- a/src/widget/ChatMarkdown.tsx
+++ b/src/widget/ChatMarkdown.tsx
@@ -157,6 +157,18 @@ function tokenizeInline(text: string): ReactNode[] {
         </a>
       ),
     },
+    {
+      // Autolink — bare URLs the model emits without `[label](url)` wrapping.
+      // Must run LAST so explicit-markdown links above win when both apply.
+      // Trim a trailing `.,;)`-like punctuation outside the match so a URL at
+      // the end of a sentence doesn't swallow the period.
+      regex: /(?<![("'<>])(https?:\/\/[^\s<>()]+[^\s<>().,;:!?])/,
+      render: ([, url]) => (
+        <a href={url} target="_blank" rel="noopener noreferrer" className="underline">
+          {url}
+        </a>
+      ),
+    },
   ];
 
   // Find the earliest match across all patterns; recurse on remainder.


### PR DESCRIPTION
## Fix

Magui (8-jun) reportó en mi.gundo.life:
1. **Markdown `**bold**` literal** — Vida ChatPage no usa ChatMarkdown (otro PR en gundo-vida arregla eso usando este export)
2. **URLs del bot como texto plano** — ChatMarkdown solo manejaba `[label](url)` markdown, no URLs bare

## Cambios

- Export `ChatMarkdown` desde el root del package.
- Agrega regex de autolink (corre LAST para no pisar markdown links explícitos). Trim de puntuación final.

## Test plan

- [x] `pnpm build` ✅
- [ ] Post-publish + Vida bump: bot menciona URL → DOM tiene `<a href>` clickeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)