### PR TITLE
feat(widget): bottomOffset prop to clear host fixed bottom bar (BUG-010) — v1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jplannnou/gundo-ui",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "packageManager": "pnpm@10.30.1",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/widget/GundoWidget.tsx
+++ b/src/widget/GundoWidget.tsx
@@ -28,6 +28,13 @@ export interface GundoWidgetProps {
    */
   onFullScreen?: () => void;
   fullScreenLabel?: string;
+  /**
+   * Extra space (in px) to lift the floating bubble and panel above the
+   * bottom edge. Use it when the host app has a fixed bottom bar the default
+   * `bottom: 1.25rem` bubble would overlap (e.g. ecom's BottomBar tap targets).
+   * Defaults to 0 (the bubble sits at the default offset).
+   */
+  bottomOffset?: number;
 }
 
 const TAB_LABELS: Record<GundoWidgetSection, string> = {
@@ -50,7 +57,16 @@ export function GundoWidget({
   defaultOpen = false,
   onFullScreen,
   fullScreenLabel = 'Pantalla completa',
+  bottomOffset = 0,
 }: GundoWidgetProps) {
+  // When the host has a fixed bottom bar, lift the bubble/panel above it.
+  // Inline style overrides the default `bottom-5` / `bottom-24` utilities.
+  const bubbleBottomStyle =
+    bottomOffset > 0
+      ? { bottom: `calc(1.25rem + ${bottomOffset}px)` }
+      : undefined;
+  const panelBottomStyle =
+    bottomOffset > 0 ? { bottom: `calc(6rem + ${bottomOffset}px)` } : undefined;
   const [open, setOpen] = useState(defaultOpen);
   const [section, setSection] = useState<GundoWidgetSection>('chat');
   const [client] = useState(() => new ChatClient(api));
@@ -155,6 +171,7 @@ export function GundoWidget({
         aria-label={open ? 'Cerrar asistente' : `Abrir ${productName}`}
         aria-expanded={open}
         aria-haspopup="dialog"
+        style={bubbleBottomStyle}
         className="fixed bottom-5 right-5 z-[9998] w-14 h-14 rounded-full bg-[var(--ui-primary)] text-[var(--ui-surface)] shadow-lg flex items-center justify-center active:scale-95 transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)] focus-visible:ring-offset-2"
       >
         {open ? <X className="w-6 h-6" aria-hidden="true" /> : <MessageCircle className="w-6 h-6" aria-hidden="true" />}
@@ -176,6 +193,7 @@ export function GundoWidget({
             animate={panelAnimate}
             exit={panelExit}
             transition={{ duration: panelDuration, ease: [0.16, 1, 0.3, 1] as const }}
+            style={panelBottomStyle}
             className="fixed bottom-24 right-5 z-[9998] w-[min(400px,calc(100vw-2.5rem))] h-[min(620px,calc(100vh-8rem))] rounded-2xl overflow-hidden border border-[var(--ui-border)] bg-[var(--ui-surface)] shadow-2xl flex flex-col"
             role="dialog"
             aria-modal="true"


### PR DESCRIPTION
## BUG-010 — FAB del chat solapa el tab "Carrito" del BottomBar (ecom)

`GundoWidget` posiciona la burbuja (`bottom-5`) y el panel (`bottom-24`) fixed bottom-right, y no exponía ningún prop de posición → en ecom se superponía al tap-target del BottomBar.

### Cambio
Nuevo prop opcional **`bottomOffset`** (px) que sube burbuja + panel por encima del borde inferior, vía override inline de las utilities default. Default `0` (sin cambios para datacenter/vida, que no tienen bottom bar).

```tsx
<GundoWidget bottomOffset={88} ... />  // ej. ecom: alto del BottomBar
```

Bump a **1.15.0**. (El autolink de URLs sueltas — BUG-021 — ya salió en 1.14.0 vía #28.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)