### PR TITLE
fix(widget): deuda responsive — dvh, safe-area, touch targets 44px

### DIFF
--- a/src/widget/ChatSection.tsx
+++ b/src/widget/ChatSection.tsx
@@ -387,7 +387,7 @@ export function ChatSection({
             type="button"
             onClick={() => fileInputRef.current?.click()}
             aria-label={labels.attach}
-            className="w-10 h-10 rounded-xl bg-[var(--ui-surface)] border border-[var(--ui-border)] flex items-center justify-center text-[var(--ui-text-muted)] active:scale-95 transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)]"
+            className="w-11 h-11 rounded-xl bg-[var(--ui-surface)] border border-[var(--ui-border)] flex items-center justify-center text-[var(--ui-text-muted)] active:scale-95 transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)]"
           >
             <Paperclip className="w-5 h-5" aria-hidden="true" />
           </button>
@@ -395,7 +395,7 @@ export function ChatSection({
             type="button"
             onClick={() => cameraInputRef.current?.click()}
             aria-label={labels.capture}
-            className="w-10 h-10 rounded-xl bg-[var(--ui-surface)] border border-[var(--ui-border)] flex items-center justify-center text-[var(--ui-text-muted)] active:scale-95 transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)]"
+            className="w-11 h-11 rounded-xl bg-[var(--ui-surface)] border border-[var(--ui-border)] flex items-center justify-center text-[var(--ui-text-muted)] active:scale-95 transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)]"
           >
             <Camera className="w-5 h-5" aria-hidden="true" />
           </button>
@@ -412,7 +412,7 @@ export function ChatSection({
             type="submit"
             aria-label={labels.send}
             disabled={(!input.trim() && !pendingFiles.length) || isStreaming}
-            className="w-10 h-10 rounded-xl bg-[var(--ui-primary)] text-[var(--ui-surface)] flex items-center justify-center disabled:opacity-50 active:scale-95 transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)] focus-visible:ring-offset-2"
+            className="w-11 h-11 rounded-xl bg-[var(--ui-primary)] text-[var(--ui-surface)] flex items-center justify-center disabled:opacity-50 active:scale-95 transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)] focus-visible:ring-offset-2"
           >
             <Send className="w-4 h-4" aria-hidden="true" />
           </button>

--- a/src/widget/GundoWidget.tsx
+++ b/src/widget/GundoWidget.tsx
@@ -59,14 +59,16 @@ export function GundoWidget({
   fullScreenLabel = 'Pantalla completa',
   bottomOffset = 0,
 }: GundoWidgetProps) {
-  // When the host has a fixed bottom bar, lift the bubble/panel above it.
-  // Inline style overrides the default `bottom-5` / `bottom-24` utilities.
-  const bubbleBottomStyle =
-    bottomOffset > 0
-      ? { bottom: `calc(1.25rem + ${bottomOffset}px)` }
-      : undefined;
-  const panelBottomStyle =
-    bottomOffset > 0 ? { bottom: `calc(6rem + ${bottomOffset}px)` } : undefined;
+  // Bubble/panel bottom = base offset + iOS home-indicator inset + host
+  // bottom bar (bottomOffset). Always inline so the safe-area inset applies
+  // even without a host offset; overrides the `bottom-5` / `bottom-24`
+  // utility fallbacks.
+  const bubbleBottomStyle = {
+    bottom: `calc(1.25rem + env(safe-area-inset-bottom, 0px) + ${bottomOffset}px)`,
+  };
+  const panelBottomStyle = {
+    bottom: `calc(6rem + env(safe-area-inset-bottom, 0px) + ${bottomOffset}px)`,
+  };
   const [open, setOpen] = useState(defaultOpen);
   const [section, setSection] = useState<GundoWidgetSection>('chat');
   const [client] = useState(() => new ChatClient(api));
@@ -194,7 +196,7 @@ export function GundoWidget({
             exit={panelExit}
             transition={{ duration: panelDuration, ease: [0.16, 1, 0.3, 1] as const }}
             style={panelBottomStyle}
-            className="fixed bottom-24 right-5 z-[9998] w-[min(400px,calc(100vw-2.5rem))] h-[min(620px,calc(100vh-8rem))] rounded-2xl overflow-hidden border border-[var(--ui-border)] bg-[var(--ui-surface)] shadow-2xl flex flex-col"
+            className="fixed bottom-24 right-5 z-[9998] w-[min(400px,calc(100vw-2.5rem))] h-[min(620px,calc(100vh-8rem))] supports-[height:100dvh]:h-[min(620px,calc(100dvh-8rem))] rounded-2xl overflow-hidden border border-[var(--ui-border)] bg-[var(--ui-surface)] shadow-2xl flex flex-col"
             role="dialog"
             aria-modal="true"
             aria-label={productName}
@@ -220,7 +222,7 @@ export function GundoWidget({
                       }}
                       aria-label={fullScreenLabel}
                       title={fullScreenLabel}
-                      className="min-w-6 min-h-6 p-1.5 rounded text-[var(--ui-text-muted)] hover:text-[var(--ui-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)]"
+                      className="min-w-11 min-h-11 flex items-center justify-center rounded text-[var(--ui-text-muted)] hover:text-[var(--ui-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)]"
                     >
                       <Maximize2 className="w-4 h-4" aria-hidden="true" />
                     </button>
@@ -228,7 +230,7 @@ export function GundoWidget({
                   <button
                     onClick={toggle}
                     aria-label="Cerrar"
-                    className="min-w-6 min-h-6 p-1.5 rounded text-[var(--ui-text-muted)] hover:text-[var(--ui-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)]"
+                    className="min-w-11 min-h-11 flex items-center justify-center rounded text-[var(--ui-text-muted)] hover:text-[var(--ui-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-primary)]"
                   >
                     <X className="w-4 h-4" aria-hidden="true" />
                   </button>


### PR DESCRIPTION
Deuda estructural del GundoWidget detectada en la auditoría responsive (afecta a los 3 consumidores: vida, ecommerce, datacenter):

1. **`100dvh`** en el panel (con fallback `100vh` vía `supports-[]`): con el teclado móvil abierto el input quedaba tapado porque `vh` no refleja el viewport real en mobile.
2. **`env(safe-area-inset-bottom)`** siempre en burbuja y panel: en iPhones con home indicator la burbuja se hundía en el clearance de la nav del host. `bottomOffset` compone encima.
3. **Touch targets 44px** (WCAG 2.5.5): cerrar/maximizar 36→44px, attach/cámara/send 40→44px.

## Verificación
- `pnpm build` ✅
- Tests: 796/798 — los 2 que fallan son `ThemeToggle` y **fallan igual en main limpio** (verificado con stash), no los toca este PR.

Publish a GitHub Packages es automático al mergear (publish.yml en push a main) → los consumidores lo levantan con el próximo bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)