### PR TITLE
feat(product): weighable display (€/kg + ≈weight) for product cards

### DIFF
--- a/src/ProductCard.tsx
+++ b/src/ProductCard.tsx
@@ -11,6 +11,15 @@ export interface ProductCardProps {
   price?: number | string;
   originalPrice?: number | string;
   currency?: string;
+  /**
+   * Weighable (variable-measure) extras — DISPLAY-ONLY. Compute with
+   * `getWeighableDisplay()`. The product is still bought as an integer unit
+   * (the storefront cart rounds weight to 1 unit); `price` is the unit price,
+   * these add the "≈weight" + derived "€/kg" transparency line + a chip.
+   */
+  weighableLabel?: string;
+  approxWeight?: string;
+  pricePerKgLabel?: string;
   score?: number;
   tags?: string[];
   description?: string;
@@ -61,6 +70,9 @@ export function ProductCard({
   price,
   originalPrice,
   currency,
+  weighableLabel,
+  approxWeight,
+  pricePerKgLabel,
   score,
   tags = [],
   description,
@@ -168,6 +180,12 @@ export function ProductCard({
           {name}
         </h3>
 
+        {weighableLabel && (
+          <span className="inline-flex w-fit items-center rounded-full bg-[var(--ui-surface-hover)] px-2 py-0.5 text-[10px] font-medium text-[var(--ui-text-secondary)]">
+            {weighableLabel}
+          </span>
+        )}
+
         {!isCompact && description && (
           <p className="line-clamp-2 text-xs text-[var(--ui-text-secondary)]">{description}</p>
         )}
@@ -198,6 +216,11 @@ export function ProductCard({
             {originalPrice !== undefined && price !== originalPrice && (
               <span className="ml-1.5 text-xs text-[var(--ui-text-muted)] line-through tabular-nums">
                 {formatPrice(originalPrice, currency)}
+              </span>
+            )}
+            {(approxWeight || pricePerKgLabel) && (
+              <span className="mt-0.5 block text-[10px] leading-tight text-[var(--ui-text-muted)] tabular-nums">
+                {[approxWeight, pricePerKgLabel].filter(Boolean).join(' · ')}
               </span>
             )}
           </div>

--- a/src/ProductCardWithExplainability.tsx
+++ b/src/ProductCardWithExplainability.tsx
@@ -25,6 +25,14 @@ export interface ExplainabilityProduct {
   reasons?: ExplainabilityProductReason[];
   /** Optional tags chip list */
   tags?: string[];
+  /**
+   * Weighable (variable-measure) extras — DISPLAY-ONLY. Compute with
+   * `getWeighableDisplay()`. `price` stays the integer-unit price; these add
+   * the "≈weight" + derived "€/kg" line + a chip. No weight selector.
+   */
+  weighableLabel?: string;
+  approxWeight?: string;
+  pricePerKgLabel?: string;
 }
 
 export type ExplainabilityProductState =
@@ -195,6 +203,12 @@ export function ProductCardWithExplainability({
           {product.name}
         </h3>
 
+        {product.weighableLabel && (
+          <span className="inline-flex w-fit items-center rounded-full bg-[var(--ui-surface-hover)] px-2 py-0.5 text-[10px] font-medium text-[var(--ui-text-secondary)]">
+            {product.weighableLabel}
+          </span>
+        )}
+
         {(suitability?.label || (suitability?.extraProfilesCount ?? 0) > 0) && (
           <div className="flex flex-wrap items-center gap-1.5">
             {suitability?.label && (
@@ -267,8 +281,15 @@ export function ProductCardWithExplainability({
         {footer}
 
         <div className="mt-auto flex items-center justify-between gap-2 pt-2">
-          <span className="text-base font-bold tabular-nums text-[var(--ui-text)]">
-            {formatPrice(product.price, product.currency)}
+          <span className="flex flex-col">
+            <span className="text-base font-bold tabular-nums text-[var(--ui-text)]">
+              {formatPrice(product.price, product.currency)}
+            </span>
+            {(product.approxWeight || product.pricePerKgLabel) && (
+              <span className="text-[10px] leading-tight text-[var(--ui-text-muted)] tabular-nums">
+                {[product.approxWeight, product.pricePerKgLabel].filter(Boolean).join(' · ')}
+              </span>
+            )}
           </span>
           {action ?? (
             <button

--- a/src/__tests__/weighable.test.tsx
+++ b/src/__tests__/weighable.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { isWeighableCode, getWeighableDisplay } from '../utils/weighable';
+
+/**
+ * Weighable (variable-measure) product helpers.
+ * Numbers verified against Ametller's SFCC catalog + live cart (2026-06-16):
+ *   - Bròquil Extra  code 2000101000006  unitPrice 1.99  ≈0.45 kg → 4,42 €/kg
+ *   - Síndria        code 2048977000003  unitPrice 6.25  ≈3.7 kg  → 1,69 €/kg
+ *   - Salmó porció   code 2018102000000  unitPrice 7.99  ≈205 g   → 38,98 €/kg
+ */
+describe('isWeighableCode', () => {
+  it('flags GS1 variable-measure barcodes (13 digits, prefix 2)', () => {
+    expect(isWeighableCode('2000101000006')).toBe(true);
+    expect(isWeighableCode('2048977000003')).toBe(true);
+  });
+
+  it('rejects regular EANs, short/long codes, and nullish', () => {
+    expect(isWeighableCode('8424395141186')).toBe(false); // normal EAN-13
+    expect(isWeighableCode('200010')).toBe(false); // too short
+    expect(isWeighableCode('20001010000061')).toBe(false); // too long
+    expect(isWeighableCode(undefined)).toBe(false);
+    expect(isWeighableCode(null)).toBe(false);
+  });
+});
+
+describe('getWeighableDisplay', () => {
+  it('derives €/kg from unit price ÷ approx weight (kg unit)', () => {
+    const d = getWeighableDisplay({
+      code: '2000101000006',
+      unitPrice: '1.99',
+      weightValue: '0.45',
+      weightUnit: 'kg (Kilograms)',
+      locale: 'es',
+      currency: 'EUR',
+    });
+    expect(d.isWeighable).toBe(true);
+    expect(d.approxWeightKg).toBeCloseTo(0.45, 5);
+    expect(d.pricePerKg).toBeCloseTo(4.42, 2);
+    expect(d.pricePerKgLabel).toContain('/kg');
+    expect(d.approxWeightLabel).toContain('kg');
+  });
+
+  it('handles gram weights (normalizes to kg for the €/kg figure)', () => {
+    const d = getWeighableDisplay({
+      code: '2018102000000',
+      unitPrice: 7.99,
+      weightValue: 205,
+      weightUnit: 'g (Grams)',
+    });
+    expect(d.approxWeightKg).toBeCloseTo(0.205, 5);
+    expect(d.pricePerKg).toBeCloseTo(38.98, 1);
+    expect(d.approxWeightLabel).toContain('g');
+  });
+
+  it('never invents a €/kg for unit-counted items (no mass weight)', () => {
+    const d = getWeighableDisplay({
+      code: '2000329000000',
+      unitPrice: 2.99,
+      weightValue: 1,
+      weightUnit: 'un (Unit)',
+    });
+    expect(d.isWeighable).toBe(true);
+    expect(d.pricePerKg).toBeNull();
+    expect(d.pricePerKgLabel).toBeNull();
+  });
+
+  it('is inert for non-weighable codes', () => {
+    const d = getWeighableDisplay({
+      code: '8424395141186',
+      unitPrice: 1.99,
+      weightValue: 250,
+      weightUnit: 'g (Grams)',
+    });
+    expect(d.isWeighable).toBe(false);
+    expect(d.pricePerKg).toBeNull();
+  });
+
+  it('does not divide by zero / unparseable inputs', () => {
+    const d = getWeighableDisplay({
+      code: '2000101000006',
+      unitPrice: 'not-a-number',
+      weightValue: '0',
+      weightUnit: 'kg',
+    });
+    expect(d.pricePerKg).toBeNull();
+    expect(d.pricePerKgLabel).toBeNull();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,4 +300,6 @@ export {
   formatList,
 } from './utils/formatLocale';
 export type { Locale } from './utils/formatLocale';
+export { isWeighableCode, getWeighableDisplay } from './utils/weighable';
+export type { WeighableDisplay, WeighableInput } from './utils/weighable';
 

--- a/src/utils/weighable.ts
+++ b/src/utils/weighable.ts
@@ -1,0 +1,170 @@
+/**
+ * Weighable (variable-measure) product helpers.
+ *
+ * GROCERY CONTEXT — verified against Ametller's SFCC storefront (2026-06-16):
+ *   - A product whose code is a GS1 *restricted-distribution / variable-measure*
+ *     barcode (13 digits, prefix "2") is sold IN-STORE by weight. ONLINE, the
+ *     storefront sells it as a fixed-price UNIT (the cart's Cart-AddProduct only
+ *     accepts INTEGER quantities — a decimal weight is silently rounded to 1).
+ *   - Therefore the catalog `price.value` is the **price per purchasable unit**
+ *     (what the checkout charges), NOT a true €/kg, even though upstream data
+ *     mislabels `price.unit` as "per kg". The `net_weight_volume` is the
+ *     **approximate weight of that unit**.
+ *   - The honest €/kg shown to the user is therefore DERIVED:
+ *         pricePerKg = unitPrice / approxWeightKg
+ *
+ * These helpers stay pure + locale-aware so any consumer (ecom, vida, datacenter)
+ * renders the same "unit price + ≈weight + (~€/kg)" contract. The purchasable
+ * quantity remains an integer unit — there is NO weight selector (see Path A).
+ */
+
+import { formatCurrency, formatNumber, type Locale } from './formatLocale';
+
+export interface WeighableDisplay {
+  /** True when the code is a GS1 variable-measure barcode (13 digits, prefix "2"). */
+  isWeighable: boolean;
+  /** Approx unit weight normalized to kilograms, or null when not resolvable. */
+  approxWeightKg: number | null;
+  /** Locale-formatted approx weight in its source unit, e.g. "≈ 0,45 kg" / "≈ 90 g". */
+  approxWeightLabel: string | null;
+  /** Derived price per kg (unitPrice ÷ approxWeightKg), or null when not derivable. */
+  pricePerKg: number | null;
+  /** Locale+currency formatted derived €/kg, e.g. "4,42 €/kg". Null when not derivable. */
+  pricePerKgLabel: string | null;
+}
+
+/** Strip a parenthetical suffix ("g (Grams)" → "g") and lowercase. */
+function cleanUnit(unit: string | null | undefined): string {
+  if (typeof unit !== 'string') return '';
+  return unit.replace(/\s*\([^)]*\)/g, '').trim().toLowerCase();
+}
+
+/** Mass-unit → kilograms multiplier. Returns null for non-mass units (volume, unit, …). */
+function massUnitToKg(unit: string): number | null {
+  switch (unit) {
+    case 'kg':
+    case 'kilogram':
+    case 'kilograms':
+    case 'kilogramo':
+    case 'kilogramos':
+      return 1;
+    case 'g':
+    case 'gram':
+    case 'grams':
+    case 'gramo':
+    case 'gramos':
+      return 0.001;
+    case 'mg':
+    case 'milligram':
+    case 'milligrams':
+      return 0.000001;
+    default:
+      return null;
+  }
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * GS1 variable-measure barcode: 13 digits, prefix "2" (restricted distribution).
+ * In-store these encode an embedded weight/price; the catalog indexes the
+ * zero-weight base code, so prefix + length is the reliable structural marker.
+ */
+export function isWeighableCode(code: string | null | undefined): boolean {
+  return typeof code === 'string' && code.length === 13 && code.startsWith('2');
+}
+
+export interface WeighableInput {
+  code?: string | null;
+  /** Catalog unit price (`price.value`) — number or BIGNUMERIC string. */
+  unitPrice?: number | string | null;
+  /** `net_weight_volume.value` — number or string. */
+  weightValue?: number | string | null;
+  /** `net_weight_volume.unit` — e.g. "kg (Kilograms)", "g (Grams)", "un (Unit)". */
+  weightUnit?: string | null;
+  locale?: Locale;
+  currency?: string;
+}
+
+/**
+ * Build the display contract for a (possibly) weighable product.
+ *
+ * `isWeighable` is driven by the code; the €/kg derivation additionally requires
+ * a resolvable mass weight — volume ("per liter") or unit-counted items return a
+ * null `pricePerKg` (we never invent a per-kg figure we can't stand behind).
+ */
+export function getWeighableDisplay(input: WeighableInput): WeighableDisplay {
+  const {
+    code,
+    unitPrice,
+    weightValue,
+    weightUnit,
+    locale = 'es',
+    currency = 'EUR',
+  } = input;
+
+  const isWeighable = isWeighableCode(code);
+
+  const rawWeight = toFiniteNumber(weightValue);
+  const cleaned = cleanUnit(weightUnit);
+  const kgPerUnit = massUnitToKg(cleaned);
+  const approxWeightKg =
+    rawWeight !== null && rawWeight > 0 && kgPerUnit !== null
+      ? rawWeight * kgPerUnit
+      : null;
+
+  // Approx weight label — keep the source unit, just format the number per locale.
+  let approxWeightLabel: string | null = null;
+  if (rawWeight !== null && rawWeight > 0 && cleaned) {
+    const abbrev = UNIT_ABBREV[cleaned] ?? cleaned;
+    approxWeightLabel = `≈ ${formatNumber(rawWeight, locale)} ${abbrev}`;
+  }
+
+  const price = toFiniteNumber(unitPrice);
+  const pricePerKg =
+    isWeighable && price !== null && price > 0 && approxWeightKg
+      ? Math.round((price / approxWeightKg) * 100) / 100
+      : null;
+  const pricePerKgLabel =
+    pricePerKg !== null
+      ? `${formatCurrency(pricePerKg, locale, currency)}/kg`
+      : null;
+
+  return {
+    isWeighable,
+    approxWeightKg,
+    approxWeightLabel,
+    pricePerKg,
+    pricePerKgLabel,
+  };
+}
+
+const UNIT_ABBREV: Record<string, string> = {
+  kilogram: 'kg',
+  kilograms: 'kg',
+  kilogramo: 'kg',
+  kilogramos: 'kg',
+  gram: 'g',
+  grams: 'g',
+  gramo: 'g',
+  gramos: 'g',
+  milligram: 'mg',
+  milligrams: 'mg',
+  liter: 'l',
+  liters: 'l',
+  litre: 'l',
+  litres: 'l',
+  litro: 'l',
+  litros: 'l',
+  milliliter: 'ml',
+  milliliters: 'ml',
+  millilitre: 'ml',
+  millilitres: 'ml',
+  unit: 'ud',
+  units: 'ud',
+  unidad: 'ud',
+  unidades: 'ud',
+};

--- a/src/widget/chat-client.ts
+++ b/src/widget/chat-client.ts
@@ -73,6 +73,13 @@ export interface ChatHealthContext {
   age?: number;
   medications?: string[];
   activePlanSummary?: string;
+  /**
+   * Short snapshot of the host's shopping state (current product / cart
+   * summary) so the assistant can answer "is THIS apt for me?" without the
+   * user re-describing the screen. Same inline-string pattern as
+   * activePlanSummary; keep it under ~600 chars.
+   */
+  activeShoppingContext?: string;
 }
 
 export interface SendMessageParams extends ChatHealthContext {
@@ -111,6 +118,8 @@ export class ChatClient {
     if (params.age) fd.append('age', String(params.age));
     if (params.medications?.length) params.medications.forEach((m) => fd.append('medications', m));
     if (params.activePlanSummary) fd.append('activePlanSummary', params.activePlanSummary);
+    if (params.activeShoppingContext)
+      fd.append('activeShoppingContext', params.activeShoppingContext);
     if (params.media?.length) params.media.forEach((file) => fd.append('media', file));
     return fd;
   }


### PR DESCRIPTION
## Qué

Display de productos **pesables** (variable-measure) en `ProductCard` y `ProductCardWithExplainability`, parte de **Path A** del rollout de balanza.

Verificado en vivo contra el storefront SFCC de Ametller (2026-06-16): los pesables (código GS1 13 dígitos prefijo `2`) se pesan en tienda pero **online se venden como unidad de precio fijo** — el carrito solo acepta cantidades enteras (un decimal se redondea a 1 en silencio). Por eso `price.value` es el **precio por unidad**, no un €/kg real (aunque el upstream lo etiqueta "per kg"), y `net_weight_volume` es el **peso aprox** de esa unidad.

## Cambios

- `utils/weighable.ts` — util compartido locale-aware: `isWeighableCode` + `getWeighableDisplay` (deriva €/kg = precio_unidad ÷ peso_kg; nunca inventa €/kg para items por unidad o por volumen). **7 unit tests** con números verificados contra SFCC (bròcoli 4,42 €/kg, sandía 1,69, salmó 38,98).
- `ProductCard` / `ProductCardWithExplainability` — props opcionales `weighableLabel` + `approxWeight` + `pricePerKgLabel` (puramente aditivas, sin cambio de comportamiento para consumers existentes).

La compra sigue siendo por **unidad entera** — NO hay selector de peso (Path A). El "add by weight" real requiere que Ametller configure SFCC como *sold-by-measure* (diferido).

## Notas

- 2 fallas preexistentes en `ThemeToggle.test.tsx` (estado de tema, ajenas a este PR — fallan también en `main` y aisladas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
