### PR TITLE
fix(a11y,test): habilitar suite *.test.ts dormida + aislamiento de tema + contraste WCAG AA del palette

### DIFF
--- a/src/__tests__/contrast.test.ts
+++ b/src/__tests__/contrast.test.ts
@@ -32,10 +32,10 @@ const DARK = {
   surface: '#292E37',
   text: '#F2F4F3',
   secondary: '#9ca3af',
-  muted: '#6b7280',
+  muted: '#828b98', // bumped from #6b7280 (2.8:1 fail even large) → 4.0:1 large-text pass
   primary: '#67C728',
   success: '#22c55e',
-  error: '#ef4444',
+  error: '#f87171', // bumped from #ef4444 (3.6:1 fail) → 4.9:1 AA pass
   warning: '#f59e0b',
   info: '#60a5fa', // bumped from #3b82f6 (3.6:1 fail) → 5.25:1 AA pass
 };
@@ -46,8 +46,8 @@ const LIGHT = {
   secondary: '#4b5563',
   muted: '#57606a',
   primary: '#08563E',
-  success: '#16a34a',
-  error: '#dc2626',
+  success: '#15803d', // bumped from #16a34a (3.0:1 fail) → 4.5:1 AA pass
+  error: '#b91c1c', // bumped from #dc2626 (4.4:1 fail) → 5.9:1 AA pass
   warning: '#92400e', // bumped from #d97706 (2.9:1 fail) → 6.4:1 AA pass
   info: '#2563eb',
 };

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -23,4 +23,15 @@ Object.defineProperty(window, 'matchMedia', {
 
 afterEach(() => {
   cleanup();
+  // Test isolation: ThemeProvider (and other components) persist to
+  // localStorage and mutate documentElement. Without resetting these between
+  // tests, persisted state leaks across cases and across files — e.g. a theme
+  // toggled to 'light' in one test made a later `defaultTheme="dark"` resolve
+  // to light. Reset both so every test starts from a clean slate.
+  try {
+    localStorage.clear();
+  } catch {
+    /* jsdom without localStorage — nothing to clear */
+  }
+  document.documentElement.classList.remove('theme-light');
 });

--- a/src/theme.css
+++ b/src/theme.css
@@ -42,14 +42,14 @@
   /* Text colors — brandbook warm off-white */
   --ui-text: #F2F4F3;
   --ui-text-secondary: #9ca3af;
-  /* ⚠ Contrast: 3.5:1 on dark surface — use only for large text (>=18px/14px bold) or decorative */
-  --ui-text-muted: #6b7280;
+  /* ⚠ Contrast: 4.0:1 on dark surface — use only for large text (>=18px/14px bold) or decorative */
+  --ui-text-muted: #828b98;
 
   /* Semantic colors */
   --ui-success: #22c55e;
   --ui-success-soft: rgb(34 197 94 / 0.15);
-  --ui-error: #ef4444;
-  --ui-error-soft: rgb(239 68 68 / 0.15);
+  --ui-error: #f87171;
+  --ui-error-soft: rgb(248 113 113 / 0.15);
   --ui-warning: #f59e0b;
   --ui-warning-soft: rgb(245 158 11 / 0.15);
   --ui-info: #60a5fa;
@@ -223,10 +223,10 @@
   /* Muted text — 5.0:1 on light surface (passes AA normal) */
   --ui-text-muted: #57606a;
 
-  --ui-success: #16a34a;
-  --ui-success-soft: rgb(22 163 74 / 0.1);
-  --ui-error: #dc2626;
-  --ui-error-soft: rgb(220 38 38 / 0.1);
+  --ui-success: #15803d;
+  --ui-success-soft: rgb(21 128 61 / 0.1);
+  --ui-error: #b91c1c;
+  --ui-error-soft: rgb(185 28 28 / 0.1);
   --ui-warning: #92400e;
   --ui-warning-soft: rgb(146 64 14 / 0.1);
   --ui-info: #2563eb;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
-    include: ['src/**/*.test.tsx'],
+    include: ['src/**/*.test.tsx', 'src/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Contexto

El `vitest.config` solo matcheaba `src/**/*.test.tsx`, así que `contrast.test.ts` **nunca corría** (bit-rot). Al habilitarlo aparecieron 2 problemas latentes que este PR resuelve.

## Cambios

**1. Aislamiento de tests** (`setup.ts`)
`ThemeProvider` persiste en `localStorage` + muta `documentElement`, pero nada lo reseteaba entre tests → un tema toggleado a 'light' se filtraba a un `defaultTheme="dark"` posterior. Reset de `localStorage` + clase `theme-light` en el `afterEach` global. **Arregla 2 fallas preexistentes de `ThemeToggle`** (fallaban incluso aisladas).

**2. Config** (`vitest.config.ts`): `+ 'src/**/*.test.ts'` → ahora corre `contrast.test.ts` y cualquier `.ts` futuro.

**3. ⚠️ Contraste WCAG AA real del palette** (`theme.css`)
El test de contraste espeja `theme.css` exacto — los valores **no estaban stale, fallaban de verdad**:

| Token | Antes | Después | Ratio |
|---|---|---|---|
| dark `--ui-error` | `#ef4444` | `#f87171` | 3.6 → **4.9** |
| dark `--ui-text-muted` | `#6b7280` | `#828b98` | 2.8 → **4.0** (bar large-text) |
| light `--ui-success` | `#16a34a` | `#15803d` | 3.0 → **4.5** |
| light `--ui-error` | `#dc2626` | `#b91c1c` | 4.4 → **5.9** |

Shades accesibles más cercanos, siguiendo el **precedente** (info/warning ya habían sido bumpeados igual). Variantes `*-soft` en sync de hue.

## ⚠️ Impacto
Esto cambia los **colores semánticos para TODOS los consumers** de @gundo/ui (shifts sutiles de shade). Los **baselines visuales (`test:visual`) pueden necesitar re-grabarse**. Al mergear a main, semantic-release publica y propaga el bump a los 10 consumers.

## Verificación
- Suite completa: **107 archivos / 821 tests verde** (incluye `contrast.test.ts` 16/16 y `ThemeToggle` 7/7).
- `tsc --noEmit` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
