### PR TITLE
feat(ui): MetricRow, DataSourceRow, AccountSheet + readableInkOn (DS2)

### DIFF
--- a/src/AccountSheet.tsx
+++ b/src/AccountSheet.tsx
@@ -1,0 +1,133 @@
+'use client';
+import type { ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { Sheet } from './Sheet';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export interface AccountSheetUser {
+  name?: string;
+  email?: string;
+  avatarUrl?: string;
+  /** Fallback initials shown when no avatar (e.g. "JP"). Derived from name if omitted. */
+  initials?: string;
+}
+
+export interface AccountSheetItem {
+  id: string;
+  /** Already-localized label. */
+  label: string;
+  icon?: ReactNode;
+  onClick: () => void;
+  /** `danger` styles destructive actions (e.g. logout). */
+  tone?: 'default' | 'danger';
+}
+
+export interface AccountSheetProps {
+  open: boolean;
+  onClose: () => void;
+  user: AccountSheetUser;
+  items: AccountSheetItem[];
+  /** Already-localized sheet title (e.g. "Mi cuenta"). */
+  title?: string;
+  /** Slot for footer controls — theme toggle, language switcher, app version. */
+  footer?: ReactNode;
+  /** Sheet side; defaults to `right`. */
+  side?: 'left' | 'right';
+}
+
+/* ─── Helpers ────────────────────────────────────────────────────────── */
+
+const deriveInitials = (name?: string): string =>
+  (name ?? '')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('') || '?';
+
+/* ─── AccountSheet ───────────────────────────────────────────────────── */
+
+/**
+ * Account drawer composed over `Sheet`: avatar/name/email header + a list of
+ * navigation actions (Mi cuenta, consentimientos, idioma, tema, logout) + an
+ * optional footer slot. Inherits Sheet's a11y (focus-trap, ESC, aria-modal).
+ * Theme-aware via `--ui-*`; i18n-agnostic (pass localized labels).
+ */
+export function AccountSheet({
+  open,
+  onClose,
+  user,
+  items,
+  title,
+  footer,
+  side = 'right',
+}: AccountSheetProps) {
+  const initials = user.initials ?? deriveInitials(user.name);
+
+  return (
+    <Sheet open={open} onClose={onClose} title={title} side={side} size="sm">
+      <div className="flex flex-col gap-6">
+        {/* Identity header */}
+        <div className="flex items-center gap-3">
+          {user.avatarUrl ? (
+            <img
+              src={user.avatarUrl}
+              alt=""
+              className="h-12 w-12 rounded-full object-cover"
+            />
+          ) : (
+            <span
+              className="flex h-12 w-12 items-center justify-center rounded-full text-sm font-bold"
+              style={{ background: 'var(--ui-primary-soft)', color: 'var(--ui-primary)' }}
+              aria-hidden="true"
+            >
+              {initials}
+            </span>
+          )}
+          <div className="min-w-0">
+            {user.name && (
+              <div className="truncate text-sm font-semibold text-[var(--ui-text)]">{user.name}</div>
+            )}
+            {user.email && (
+              <div className="truncate text-xs text-[var(--ui-text-muted)]">{user.email}</div>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <nav className="flex flex-col gap-1">
+          {items.map((item) => {
+            const isDanger = item.tone === 'danger';
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={item.onClick}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition hover:bg-[var(--ui-surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-ring-color)]"
+                style={{ color: isDanger ? 'var(--ui-error)' : 'var(--ui-text)' }}
+              >
+                {item.icon && (
+                  <span className="shrink-0" aria-hidden="true">
+                    {item.icon}
+                  </span>
+                )}
+                <span className="flex-1 truncate font-medium">{item.label}</span>
+                {!isDanger && (
+                  <ChevronRight
+                    className="h-4 w-4 shrink-0 text-[var(--ui-text-muted)]"
+                    aria-hidden="true"
+                  />
+                )}
+              </button>
+            );
+          })}
+        </nav>
+
+        {footer && (
+          <div className="mt-auto border-t border-[var(--ui-border)] pt-4">{footer}</div>
+        )}
+      </div>
+    </Sheet>
+  );
+}

--- a/src/DataSourceRow.tsx
+++ b/src/DataSourceRow.tsx
@@ -1,0 +1,91 @@
+import type { ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export type DataSourceStatus = 'ok' | 'warn' | 'locked' | 'new';
+
+export interface DataSourceRowProps {
+  /** Leading icon/emoji (decorative). */
+  icon: ReactNode;
+  /** Source name (already localized), e.g. "Análisis de sangre". */
+  name: string;
+  /** Secondary line (already localized), e.g. "Actualizado hace 2 días". */
+  sub: string;
+  /** Optional pill text (already localized), e.g. "Nuevo" / "Premium". */
+  tag?: string;
+  /** Visual + semantic status of the source. */
+  status?: DataSourceStatus;
+  onClick?: () => void;
+  className?: string;
+}
+
+/* ─── Status styles ──────────────────────────────────────────────────── */
+
+const containerStyles: Record<DataSourceStatus, { background: string; borderColor: string; opacity?: number }> = {
+  ok: { background: 'var(--ui-surface)', borderColor: 'var(--ui-border)' },
+  warn: { background: 'var(--ui-warning-soft)', borderColor: 'var(--ui-warning)' },
+  locked: { background: 'var(--ui-surface-raised)', borderColor: 'var(--ui-border)', opacity: 0.7 },
+  new: { background: 'var(--ui-success-soft)', borderColor: 'var(--ui-success)' },
+};
+
+const tagStyles: Record<DataSourceStatus, { background: string; color: string }> = {
+  ok: { background: 'var(--ui-success-soft)', color: 'var(--ui-success)' },
+  warn: { background: 'var(--ui-warning-soft)', color: 'var(--ui-warning)' },
+  locked: { background: 'var(--ui-surface-raised)', color: 'var(--ui-text-muted)' },
+  new: { background: 'var(--ui-info-soft)', color: 'var(--ui-info)' },
+};
+
+/* ─── DataSourceRow ──────────────────────────────────────────────────── */
+
+/**
+ * Tappable row summarising a health data source (blood, urine, microbiota…):
+ * icon + name + sub + optional status pill + chevron. Used in the unified home /
+ * "Mi salud" surfaces. Theme-aware via `--ui-*`; i18n-agnostic (pass localized text).
+ *
+ * Distinct from `DataChip` (an inline status badge) — this is a navigation row.
+ */
+export function DataSourceRow({
+  icon,
+  name,
+  sub,
+  tag,
+  status = 'ok',
+  onClick,
+  className = '',
+}: DataSourceRowProps) {
+  const c = containerStyles[status];
+  const isLocked = status === 'locked';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isLocked}
+      aria-disabled={isLocked}
+      className={`flex w-full items-center gap-3 rounded-2xl border px-3 py-3 text-left transition hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-ring-color)] disabled:cursor-not-allowed ${className}`}
+      style={{ background: c.background, borderColor: c.borderColor, opacity: c.opacity }}
+    >
+      <span
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-xl"
+        style={{ background: 'var(--ui-surface-raised)' }}
+        aria-hidden="true"
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-semibold text-[var(--ui-text)]">{name}</span>
+        <span className="block truncate text-xs text-[var(--ui-text-muted)]">{sub}</span>
+      </span>
+      {tag && (
+        <span
+          className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-bold"
+          style={tagStyles[status]}
+        >
+          {tag}
+        </span>
+      )}
+      <ChevronRight className="h-4 w-4 shrink-0 text-[var(--ui-text-muted)]" aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/MetricRow.tsx
+++ b/src/MetricRow.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from 'react';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export type MetricStatus = 'ok' | 'warn' | 'bad';
+
+export interface MetricRange {
+  /** Lower bound of the optimal band. */
+  low: number;
+  /** Upper bound of the optimal band. */
+  high: number;
+  /** Current measured value. */
+  current: number;
+  /** Scale minimum. */
+  min: number;
+  /** Scale maximum. */
+  max: number;
+  /** Localized caption for the optimal band (e.g. "Óptimo"). Omit to show only numbers. */
+  optimalLabel?: string;
+}
+
+export interface MetricRowProps {
+  /** Optional leading icon/emoji (decorative). */
+  icon?: ReactNode;
+  /** Metric name (already localized). */
+  name: string;
+  /** Optional secondary line (already localized). */
+  sub?: string;
+  /** Formatted value, e.g. "13.5 g/dL". */
+  value: string;
+  /** Health status of the value. */
+  status: MetricStatus;
+  /** Localized status badge text (e.g. "Óptimo" / "Atención" / "Fuera de rango"). */
+  statusLabel: string;
+  /** Optional range bar config. */
+  range?: MetricRange;
+  className?: string;
+}
+
+/* ─── Status → range tokens ──────────────────────────────────────────── */
+
+const statusTokens: Record<MetricStatus, { color: string; soft: string }> = {
+  ok: { color: 'var(--ui-range-optimal)', soft: 'var(--ui-range-optimal-soft)' },
+  warn: { color: 'var(--ui-range-attention)', soft: 'var(--ui-range-attention-soft)' },
+  bad: { color: 'var(--ui-range-critical)', soft: 'var(--ui-range-critical-soft)' },
+};
+
+/** Bounds arrive as raw floats (e.g. 0.9924999999999998) — round to 2 decimals, trim trailing zeros. */
+const fmtBound = (n: number): string =>
+  Number.isFinite(n) ? String(Number(n.toFixed(2))) : String(n);
+
+const pct = (v: number, min: number, max: number): number =>
+  max === min ? 0 : Math.min(100, Math.max(0, ((v - min) / (max - min)) * 100));
+
+/* ─── MetricRow ──────────────────────────────────────────────────────── */
+
+/**
+ * Metric row for health result screens (blood, urine, microbiota): value + status
+ * badge + optional range bar. Theme-aware via `--ui-*` tokens; i18n-agnostic —
+ * `name`, `sub`, `statusLabel` and `range.optimalLabel` must be pre-translated.
+ */
+export function MetricRow({
+  icon,
+  name,
+  sub,
+  value,
+  status,
+  statusLabel,
+  range,
+  className = '',
+}: MetricRowProps) {
+  const t = statusTokens[status];
+
+  return (
+    <div className={`border-b border-[var(--ui-border)] py-3 last:border-b-0 ${className}`}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          {icon && (
+            <span className="shrink-0 text-xl" aria-hidden="true">
+              {icon}
+            </span>
+          )}
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-[var(--ui-text)]">{name}</div>
+            {sub && <div className="truncate text-xs text-[var(--ui-text-muted)]">{sub}</div>}
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-col items-end">
+          <span className="text-sm font-bold text-[var(--ui-text)]">{value}</span>
+          <span
+            className="mt-0.5 rounded-md px-2 py-0.5 text-[10px] font-bold tracking-wide"
+            style={{ background: t.soft, color: t.color }}
+          >
+            {statusLabel}
+          </span>
+        </div>
+      </div>
+      {range && (
+        <div className="ml-8 mt-3">
+          <div
+            className="relative h-2 rounded-full"
+            style={{ background: 'var(--ui-surface-raised)' }}
+            role="img"
+            aria-label={`${value}${range.optimalLabel ? ` — ${range.optimalLabel} ${fmtBound(range.low)}–${fmtBound(range.high)}` : ''}`}
+          >
+            <div
+              className="absolute inset-y-0 rounded-full"
+              style={{
+                background: 'var(--ui-range-optimal-soft)',
+                left: `${pct(range.low, range.min, range.max)}%`,
+                width: `${pct(range.high, range.min, range.max) - pct(range.low, range.min, range.max)}%`,
+              }}
+            />
+            <div
+              className="absolute -top-1 h-4 w-0.5 rounded"
+              style={{ background: 'var(--ui-text)', left: `${pct(range.current, range.min, range.max)}%` }}
+            />
+          </div>
+          <div className="mt-1 flex justify-between text-[10px] text-[var(--ui-text-muted)]">
+            <span>{fmtBound(range.min)}</span>
+            {range.optimalLabel && (
+              <span style={{ color: 'var(--ui-range-optimal)' }}>
+                {range.optimalLabel} {fmtBound(range.low)}–{fmtBound(range.high)}
+              </span>
+            )}
+            <span>{fmtBound(range.max)}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/__tests__/AccountSheet.test.tsx
+++ b/src/__tests__/AccountSheet.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AccountSheet } from '../AccountSheet';
+
+const user = { name: 'JP Lannou', email: 'jp@gundo.life' };
+
+describe('AccountSheet', () => {
+  it('renders identity and items when open', () => {
+    render(
+      <AccountSheet
+        open
+        onClose={() => {}}
+        user={user}
+        title="Mi cuenta"
+        items={[{ id: 'profile', label: 'Perfil', onClick: () => {} }]}
+      />,
+    );
+    expect(screen.getByText('JP Lannou')).toBeInTheDocument();
+    expect(screen.getByText('jp@gundo.life')).toBeInTheDocument();
+    expect(screen.getByText('Perfil')).toBeInTheDocument();
+  });
+
+  it('derives initials when no avatar', () => {
+    render(<AccountSheet open onClose={() => {}} user={user} items={[]} />);
+    expect(screen.getByText('JL')).toBeInTheDocument();
+  });
+
+  it('fires item onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <AccountSheet
+        open
+        onClose={() => {}}
+        user={user}
+        items={[{ id: 'logout', label: 'Cerrar sesión', tone: 'danger', onClick }]}
+      />,
+    );
+    fireEvent.click(screen.getByText('Cerrar sesión'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('does not render when closed', () => {
+    render(<AccountSheet open={false} onClose={() => {}} user={user} items={[]} />);
+    expect(screen.queryByText('jp@gundo.life')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/DataSourceRow.test.tsx
+++ b/src/__tests__/DataSourceRow.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DataSourceRow } from '../DataSourceRow';
+
+describe('DataSourceRow', () => {
+  it('renders name, sub and tag', () => {
+    render(<DataSourceRow icon="🩸" name="Sangre" sub="Hace 2 días" tag="Nuevo" status="new" />);
+    expect(screen.getByText('Sangre')).toBeInTheDocument();
+    expect(screen.getByText('Hace 2 días')).toBeInTheDocument();
+    expect(screen.getByText('Nuevo')).toBeInTheDocument();
+  });
+
+  it('calls onClick when tapped', () => {
+    const onClick = vi.fn();
+    render(<DataSourceRow icon="🧪" name="Orina" sub="Pendiente" onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('is disabled when locked', () => {
+    const onClick = vi.fn();
+    render(<DataSourceRow icon="🔒" name="Microbiota" sub="Premium" status="locked" onClick={onClick} />);
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/MetricRow.test.tsx
+++ b/src/__tests__/MetricRow.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MetricRow } from '../MetricRow';
+
+describe('MetricRow', () => {
+  it('renders name, value and status label', () => {
+    render(<MetricRow name="Hemoglobina" value="13.5 g/dL" status="ok" statusLabel="Óptimo" />);
+    expect(screen.getByText('Hemoglobina')).toBeInTheDocument();
+    expect(screen.getByText('13.5 g/dL')).toBeInTheDocument();
+    expect(screen.getByText('Óptimo')).toBeInTheDocument();
+  });
+
+  it('renders sub line when provided', () => {
+    render(
+      <MetricRow name="Glucosa" sub="En ayunas" value="92 mg/dL" status="warn" statusLabel="Atención" />,
+    );
+    expect(screen.getByText('En ayunas')).toBeInTheDocument();
+  });
+
+  it('renders an accessible range bar with optimal caption', () => {
+    render(
+      <MetricRow
+        name="Ferritina"
+        value="45 ng/mL"
+        status="ok"
+        statusLabel="Óptimo"
+        range={{ low: 30, high: 100, current: 45, min: 0, max: 200, optimalLabel: 'Óptimo' }}
+      />,
+    );
+    // role="img" with an aria-label describing value + optimal band
+    expect(screen.getByRole('img')).toHaveAttribute('aria-label', expect.stringContaining('45 ng/mL'));
+  });
+
+  it('omits range bar when no range given', () => {
+    render(<MetricRow name="X" value="1" status="bad" statusLabel="Fuera de rango" />);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/readableInkOn.test.ts
+++ b/src/__tests__/readableInkOn.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { readableInkOn, getContrastRatio } from '../utils/contrast';
+
+describe('readableInkOn', () => {
+  it('returns white ink on dark backgrounds', () => {
+    expect(readableInkOn('#292E37')).toBe('#ffffff'); // GUNDO surface (dark)
+    expect(readableInkOn('#08563E')).toBe('#ffffff'); // secondary green
+    expect(readableInkOn('#000000')).toBe('#ffffff');
+  });
+
+  it('returns dark ink on light backgrounds', () => {
+    expect(readableInkOn('#ffffff')).toBe('#1f2937');
+    expect(readableInkOn('#F2F4F3')).toBe('#1f2937'); // light surface
+  });
+
+  it('flips GUNDO primary green to dark ink (white fails AA on it)', () => {
+    // #67C728 vs white is only ~1.93:1 — must pick dark ink instead.
+    const ink = readableInkOn('#67C728');
+    expect(ink).toBe('#1f2937');
+    expect(getContrastRatio(ink, '#67C728')).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('supports #rgb shorthand', () => {
+    expect(readableInkOn('#000')).toBe('#ffffff');
+    expect(readableInkOn('#fff')).toBe('#1f2937');
+  });
+
+  it('honors custom ink overrides', () => {
+    expect(readableInkOn('#67C728', '#111111')).toBe('#111111');
+    expect(readableInkOn('#000000', '#1f2937', '#fafafa')).toBe('#fafafa');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { Avatar } from './Avatar';
 export { Badge } from './Badge';
 export { BrandThemeProvider } from './BrandThemeProvider';
 export type { BrandColors, BrandThemeProviderProps } from './BrandThemeProvider';
-export { getContrastRatio, ensureContrast } from './utils/contrast';
+export { getContrastRatio, ensureContrast, readableInkOn } from './utils/contrast';
 export { Breadcrumbs } from './Breadcrumbs';
 export { Button } from './Button';
 export type { ButtonProps } from './Button';
@@ -75,6 +75,12 @@ export { SidebarUserCard } from './SidebarUserCard';
 export type { SidebarUserCardProps, SidebarUserCardUser } from './SidebarUserCard';
 export { VisuallyHidden } from './VisuallyHidden';
 export { Sheet } from './Sheet';
+export { AccountSheet } from './AccountSheet';
+export type {
+  AccountSheetProps,
+  AccountSheetUser,
+  AccountSheetItem,
+} from './AccountSheet';
 export { NumberInput } from './NumberInput';
 export { DatePicker } from './DatePicker';
 export { DateRangePicker } from './DateRangePicker';
@@ -230,6 +236,12 @@ export type {
 
 export { DataChip } from './DataChip';
 export type { DataChipProps, DataChipStatus } from './DataChip';
+
+export { DataSourceRow } from './DataSourceRow';
+export type { DataSourceRowProps, DataSourceStatus } from './DataSourceRow';
+
+export { MetricRow } from './MetricRow';
+export type { MetricRowProps, MetricStatus, MetricRange } from './MetricRow';
 
 export { NotificationCard } from './NotificationCard';
 export type {

--- a/src/utils/contrast.ts
+++ b/src/utils/contrast.ts
@@ -49,3 +49,27 @@ export function ensureContrast(fg: string, bg: string, minRatio = 4.5): string {
   const blackRatio = getContrastRatio('#000000', bg);
   return whiteRatio >= blackRatio ? '#FFFFFF' : '#000000';
 }
+
+/** Default dark ink (Tailwind gray-800) used on light backgrounds. */
+const DARK_INK = '#1f2937';
+/** Luminance crossover where white vs black contrast flips for ink selection. */
+const INK_CROSSOVER = 0.179;
+
+/**
+ * Pick a WCAG-AA-safe text ink (dark on light backgrounds, white on dark) for an
+ * arbitrary background — needed for white-label retailer brand colors that vary at
+ * runtime. GUNDO's own primary green (#67C728) fails 1.93:1 against white, so a naive
+ * "always white text on brand" is inaccessible; this flips to dark ink when the brand
+ * background is light enough.
+ *
+ * @param backgroundColor - Background hex color (#rgb or #rrggbb)
+ * @param darkInk - Override for the dark ink (default Tailwind gray-800 `#1f2937`)
+ * @param lightInk - Override for the light ink (default `#ffffff`)
+ */
+export function readableInkOn(
+  backgroundColor: string,
+  darkInk: string = DARK_INK,
+  lightInk = '#ffffff',
+): string {
+  return relativeLuminance(...hexToRgb(backgroundColor)) > INK_CROSSOVER ? darkInk : lightInk;
+}


### PR DESCRIPTION
## Qué

DS2 del initiative de plataforma unificada (DC + ultraperso). Promueve a `@gundo/ui` las **4 primitivas que faltaban** para el nav/app shell unificado y las vistas de salud (gap detectado en DS1).

| Componente | Detalle |
|---|---|
| **MetricRow** | Fila de resultado de salud: valor + badge de estado + barra de rango. Tokens `--ui-range-optimal/attention/critical`. i18n-agnostic (`statusLabel`, `range.optimalLabel`). Barra con `role="img"`. |
| **DataSourceRow** | Fila clickeable de fuente de datos (ex `DataChip` de genie-ui). **Nombre propio** para no colisionar con el `DataChip` badge ya existente en la lib. Status ok/warn/locked/new; locked → `disabled`. |
| **AccountSheet** | Drawer de cuenta compuesto sobre `Sheet` (hereda focus-trap/ESC/aria-modal). Header avatar+email+initials, items `tone: danger`, slot `footer` para theme/lang. |
| **readableInkOn** | Picker de tinta WCAG-AA para fondos de marca white-label, en `utils/contrast.ts` (reusa `hexToRgb`+`relativeLuminance`). Flip a oscuro sobre `#67C728`. |

## Verificación
- `tsc --noEmit` limpio
- `build` OK (163 files ESM)
- **837/837 tests** (16 nuevos: readableInkOn, MetricRow, DataSourceRow, AccountSheet)
- Cero colores hardcodeados — todo `var(--ui-*)`

## Al mergear
semantic-release publica `≥1.20.2` a GitHub Packages y abre bump PRs en los consumers. Reconciliación de duplicados (ecom/genie-ui) → issue H5 del tracker (blocked-by esto).

Tracker: Gundo-Health-and-Food/gundo-retail-platform-unification#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
