### PR TITLE
fix(camera): align CameraView & BarcodeScannerView to gu-* classes

### DIFF
--- a/src/BarcodeScannerView.tsx
+++ b/src/BarcodeScannerView.tsx
@@ -1,4 +1,5 @@
 'use client';
+import './ui-classes.css';
 import { useEffect, useRef, useState } from 'react';
 import { CameraOff, Keyboard, RefreshCw } from 'lucide-react';
 import { useCamera, captureVideoFrame } from './utils/useCamera';
@@ -74,30 +75,30 @@ export function BarcodeScannerView({
   }, [ready, detected, decode, onDetected, intervalMs, maxDimension, videoRef]);
 
   return (
-    <div className={`relative flex h-full w-full flex-col overflow-hidden rounded-[var(--ui-radius-lg)] bg-black ${className}`}>
+    <div className={`relative flex h-full w-full flex-col overflow-hidden gu-rounded-radius-lg bg-black ${className}`}>
       <video ref={videoRef} playsInline muted autoPlay className="h-full w-full flex-1 object-cover" aria-label="Barcode scanner camera feed" />
 
       {/* Reticle */}
       {ready && (
         <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-4">
-          <div className="relative h-32 w-72 max-w-[80%] rounded-[var(--ui-radius-md)] border-2 border-[var(--ui-primary)] shadow-[0_0_0_9999px_rgba(0,0,0,0.45)]">
-            <span className="absolute inset-x-0 top-1/2 h-0.5 -translate-y-1/2 animate-pulse bg-[var(--ui-primary)]" />
+          <div className="relative h-32 w-72 max-w-[80%] gu-rounded-radius-md border-2 gu-border-primary shadow-[0_0_0_9999px_rgba(0,0,0,0.45)]">
+            <span className="absolute inset-x-0 top-1/2 h-0.5 -translate-y-1/2 animate-pulse gu-bg-primary" />
           </div>
-          {hint && <p className="rounded-[var(--ui-radius-sm)] bg-black/50 px-3 py-1 text-sm text-white">{hint}</p>}
+          {hint && <p className="gu-rounded-radius-sm bg-black/50 px-3 py-1 text-sm text-white">{hint}</p>}
         </div>
       )}
 
       {/* Permission / error */}
       {!ready && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-[var(--ui-surface)] p-6 text-center">
-          <CameraOff className="h-10 w-10 text-[var(--ui-text-muted)]" aria-hidden="true" />
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 gu-bg-surface p-6 text-center">
+          <CameraOff className="h-10 w-10 gu-text-text-muted" aria-hidden="true" />
           {(error || permissionHint) && (
-            <p className="text-sm text-[var(--ui-text-secondary)]">{error ?? permissionHint}</p>
+            <p className="text-sm gu-text-text-secondary">{error ?? permissionHint}</p>
           )}
           <button
             type="button"
             onClick={() => void start()}
-            className="ui-focus-ring inline-flex items-center gap-2 rounded-[var(--ui-radius-md)] bg-[var(--ui-primary)] px-4 py-2 text-sm font-medium text-[var(--ui-surface)] transition-colors hover:bg-[var(--ui-primary-hover)]"
+            className="ui-focus-ring inline-flex items-center gap-2 gu-rounded-radius-md gu-bg-primary px-4 py-2 text-sm font-medium gu-text-surface transition-colors gu-h-bg-primary-hover"
           >
             <RefreshCw className="h-4 w-4" aria-hidden="true" />
             {startLabel}
@@ -111,7 +112,7 @@ export function BarcodeScannerView({
           <button
             type="button"
             onClick={onManualEntry}
-            className="ui-focus-ring inline-flex items-center gap-2 rounded-[var(--ui-radius-md)] bg-black/55 px-4 py-2 text-sm font-medium text-white backdrop-blur transition-colors hover:bg-black/70"
+            className="ui-focus-ring inline-flex items-center gap-2 gu-rounded-radius-md bg-black/55 px-4 py-2 text-sm font-medium text-white backdrop-blur transition-colors hover:bg-black/70"
           >
             <Keyboard className="h-4 w-4" aria-hidden="true" />
             {manualLabel}

--- a/src/CameraView.tsx
+++ b/src/CameraView.tsx
@@ -1,4 +1,5 @@
 'use client';
+import './ui-classes.css';
 import { useEffect, type ReactNode } from 'react';
 import { Camera, CameraOff, RefreshCw } from 'lucide-react';
 import { useCamera, captureVideoFrame, type CameraFacing } from './utils/useCamera';
@@ -55,7 +56,7 @@ export function CameraView({
 
   return (
     <div
-      className={`relative flex h-full w-full flex-col overflow-hidden rounded-[var(--ui-radius-lg)] bg-black ${className}`}
+      className={`relative flex h-full w-full flex-col overflow-hidden gu-rounded-radius-lg bg-black ${className}`}
     >
       <video
         ref={videoRef}
@@ -71,15 +72,15 @@ export function CameraView({
 
       {/* Permission / error state */}
       {!ready && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-[var(--ui-surface)] p-6 text-center">
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 gu-bg-surface p-6 text-center">
           {error ? (
             <>
-              <CameraOff className="h-10 w-10 text-[var(--ui-error)]" aria-hidden="true" />
-              <p className="text-sm text-[var(--ui-text-secondary)]">{error}</p>
+              <CameraOff className="h-10 w-10 gu-text-error" aria-hidden="true" />
+              <p className="text-sm gu-text-text-secondary">{error}</p>
               <button
                 type="button"
                 onClick={() => void start()}
-                className="ui-focus-ring inline-flex items-center gap-2 rounded-[var(--ui-radius-md)] bg-[var(--ui-primary)] px-4 py-2 text-sm font-medium text-[var(--ui-surface)] transition-colors hover:bg-[var(--ui-primary-hover)]"
+                className="ui-focus-ring inline-flex items-center gap-2 gu-rounded-radius-md gu-bg-primary px-4 py-2 text-sm font-medium gu-text-surface transition-colors gu-h-bg-primary-hover"
               >
                 <RefreshCw className="h-4 w-4" aria-hidden="true" />
                 {startLabel}
@@ -87,12 +88,12 @@ export function CameraView({
             </>
           ) : (
             <>
-              <Camera className="h-10 w-10 text-[var(--ui-text-muted)]" aria-hidden="true" />
-              {permissionHint && <p className="text-sm text-[var(--ui-text-secondary)]">{permissionHint}</p>}
+              <Camera className="h-10 w-10 gu-text-text-muted" aria-hidden="true" />
+              {permissionHint && <p className="text-sm gu-text-text-secondary">{permissionHint}</p>}
               <button
                 type="button"
                 onClick={() => void start()}
-                className="ui-focus-ring inline-flex items-center gap-2 rounded-[var(--ui-radius-md)] bg-[var(--ui-primary)] px-4 py-2 text-sm font-medium text-[var(--ui-surface)] transition-colors hover:bg-[var(--ui-primary-hover)]"
+                className="ui-focus-ring inline-flex items-center gap-2 gu-rounded-radius-md gu-bg-primary px-4 py-2 text-sm font-medium gu-text-surface transition-colors gu-h-bg-primary-hover"
               >
                 <Camera className="h-4 w-4" aria-hidden="true" />
                 {startLabel}
@@ -109,7 +110,7 @@ export function CameraView({
             type="button"
             onClick={handleCapture}
             aria-label={captureLabel}
-            className="ui-focus-ring flex h-16 w-16 items-center justify-center rounded-full border-4 border-white/80 bg-[var(--ui-primary)] text-[var(--ui-surface)] shadow-lg transition-transform active:scale-95"
+            className="ui-focus-ring flex h-16 w-16 items-center justify-center rounded-full border-4 border-white/80 gu-bg-primary gu-text-surface shadow-lg transition-transform active:scale-95"
           >
             <Camera className="h-7 w-7" aria-hidden="true" />
           </button>

--- a/src/ui-classes.css
+++ b/src/ui-classes.css
@@ -73,6 +73,7 @@
 .gu-h-text-text:hover{color:var(--ui-text)}
 .gu-rounded-radius-lg{border-radius:var(--ui-radius-lg)}
 .gu-rounded-radius-md{border-radius:var(--ui-radius-md)}
+.gu-rounded-radius-sm{border-radius:var(--ui-radius-sm)}
 .gu-rounded-radius-xl{border-radius:var(--ui-radius-xl)}
 .gu-shadow-shadow-lg{box-shadow:var(--ui-shadow-lg)}
 .gu-shadow-shadow-md{box-shadow:var(--ui-shadow-md)}


### PR DESCRIPTION
## Qué

Los 2 componentes de cámara (`CameraView`, `BarcodeScannerView`) entraron por #48 en una rama worktree aparte y **reintrodujeron los arbitrary-values `*-[var(--ui-*)]`** que la migración #49/#50 eliminó en los otros 104 componentes. Esta PR los alinea a las clases estáticas `gu-*`.

## Cambios
- `CameraView.tsx` + `BarcodeScannerView.tsx`: todos los `bg-/text-/border-/rounded-[var(--ui-*)]` → clases `gu-*` + `import ''./ui-classes.css''`.
- `ui-classes.css`: agrega `gu-rounded-radius-sm` (faltaba; había lg/md/xl).
- Los arbitrary NO-token (`bg-black/55`, `shadow-[...]`, `border-white/80`) quedan — mismo criterio que la migración.

## Impacto
- **0 cambio visual/funcional.** Render idéntico.
- Restaura cobertura de contraste axe + protege a consumers que no escanean gundo-ui con `@source`.
- Consumer actual (`gundo-ocr-pwa`, `^1.26.0`) lo toma en el próximo `pnpm install`.

## Verificación
- `pnpm build` ✅ (tsc + css copy)
- `pnpm test` ✅ **840/840**
- 0 `[var(--ui-` restantes en ambos archivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)