### PR TITLE
fix(AnimatedCounter): re-animar cuando `to` cambia estando en viewport

### DIFF
--- a/src/__tests__/AnimatedCounter.test.tsx
+++ b/src/__tests__/AnimatedCounter.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Spy compartido para las llamadas a spring.set, expuesto vía vi.hoisted para
+// poder leerlo tras mockear motion/react.
+const { setSpy } = vi.hoisted(() => ({ setSpy: vi.fn() }));
+
+// Mockeamos motion/react: el contador entra en viewport (useInView → true), el
+// spring expone un .set espiable y el transform devuelve el string final. Así
+// testeamos la lógica del efecto sin depender de IntersectionObserver / RAF.
+vi.mock("motion/react", () => ({
+  useInView: () => true,
+  useSpring: () => ({ set: setSpy, get: () => 0 }),
+  useTransform: (_spring: unknown, fn: (v: number) => string) => fn(0),
+  motion: {
+    span: ({ children, ...rest }: React.ComponentProps<"span">) => (
+      <span {...rest}>{children}</span>
+    ),
+  },
+}));
+
+// useReducedMotion → false para ejercer la ruta animada (no el fallback directo).
+vi.mock("../utils/useReducedMotion", () => ({
+  useReducedMotion: () => false,
+}));
+
+import { AnimatedCounter } from "../motion/AnimatedCounter";
+
+describe("AnimatedCounter", () => {
+  beforeEach(() => setSpy.mockClear());
+
+  it("anima al target inicial cuando entra en viewport", () => {
+    render(<AnimatedCounter to={2} />);
+    expect(setSpy).toHaveBeenCalledWith(2);
+  });
+
+  it("RE-anima cuando `to` cambia estando ya en viewport (dato async que llega tarde)", () => {
+    const { rerender } = render(<AnimatedCounter to={2} />);
+    expect(setSpy).toHaveBeenCalledWith(2);
+
+    // El valor real llega después (p. ej. una query que resuelve): NO debe
+    // quedarse congelado en el parcial.
+    rerender(<AnimatedCounter to={4} />);
+    expect(setSpy).toHaveBeenCalledWith(4);
+  });
+});

--- a/src/motion/AnimatedCounter.tsx
+++ b/src/motion/AnimatedCounter.tsx
@@ -1,8 +1,9 @@
-'use client';
-import { useEffect, useRef } from 'react';
-import { useSpring, useTransform, motion, useInView } from 'motion/react';
-import { useReducedMotion } from '../utils/useReducedMotion';
-import { spring as springPresets, durations } from './tokens';
+"use client";
+import { useEffect, useRef } from "react";
+// (useRef sigue en uso para el ref del span)
+import { useSpring, useTransform, motion, useInView } from "motion/react";
+import { useReducedMotion } from "../utils/useReducedMotion";
+import { spring as springPresets, durations } from "./tokens";
 
 export interface AnimatedCounterProps {
   /** Target value to count up to */
@@ -25,21 +26,25 @@ export interface AnimatedCounterProps {
  * Number that counts up with a spring once it enters the viewport.
  * Ported from Gundo Vida landing animations.
  *
+ * Re-anima cuando `to` cambia estando ya en viewport: es común alimentar este
+ * contador con datos ASÍNCRONOS (queries que resuelven después del montaje). La
+ * versión previa animaba una sola vez (`hasAnimatedRef`) e ignoraba cambios de
+ * `to`, así que un valor que llegaba tarde se quedaba congelado en el parcial.
+ *
  * With `prefers-reduced-motion` the final value renders immediately.
  */
 export function AnimatedCounter({
   to,
-  prefix = '',
-  suffix = '',
-  className = '',
+  prefix = "",
+  suffix = "",
+  className = "",
   duration = durations.count,
   locale,
   formatValue,
 }: AnimatedCounterProps) {
   const ref = useRef<HTMLSpanElement>(null);
-  const isInView = useInView(ref, { once: true, margin: '-60px' });
+  const isInView = useInView(ref, { once: true, margin: "-60px" });
   const prefersReduced = useReducedMotion();
-  const hasAnimatedRef = useRef(false);
 
   const format = (value: number) =>
     formatValue ? formatValue(value) : value.toLocaleString(locale);
@@ -49,22 +54,31 @@ export function AnimatedCounter({
     duration: duration * 1000,
   });
 
-  const display = useTransform(spring, (v) => `${prefix}${format(Math.round(v))}${suffix}`);
+  const display = useTransform(
+    spring,
+    (v) => `${prefix}${format(Math.round(v))}${suffix}`,
+  );
 
+  // Una vez en viewport, seguir al target: la primera vez anima 0→to; si `to`
+  // cambia después (dato async que llega tarde) anima el valor actual→to. No
+  // usamos un latch de "ya animé" — eso congelaba el contador en el parcial.
   useEffect(() => {
-    if (isInView && !hasAnimatedRef.current) {
-      spring.set(to);
-      hasAnimatedRef.current = true;
-    }
+    if (isInView) spring.set(to);
   }, [isInView, to, spring]);
 
   if (prefersReduced) {
     return (
       <span ref={ref} className={className}>
-        {prefix}{format(to)}{suffix}
+        {prefix}
+        {format(to)}
+        {suffix}
       </span>
     );
   }
 
-  return <motion.span ref={ref} className={className}>{display}</motion.span>;
+  return (
+    <motion.span ref={ref} className={className}>
+      {display}
+    </motion.span>
+  );
 }


### PR DESCRIPTION
## Bug
`AnimatedCounter` animaba **una sola vez** al entrar en viewport (`hasAnimatedRef`) y luego **ignoraba cambios de `to`**. Alimentado con datos **asíncronos** (queries que resuelven tras el montaje), el valor que llegaba tarde quedaba **congelado en el parcial**.

Caso real (gundo-ecommerce-ui): el hero de la home mostraba "2/4 fuentes de datos activas" a usuarios con las 4 — el conteo subía `0→2→4` (sangre/orina resuelven antes que el analyzer) y el contador se pegaba en 2. Se parcheó del lado consumidor (gate `dataLoading`), pero la causa es de la librería y afecta a cualquier consumidor con valores async.

## Fix
Se elimina el latch `hasAnimatedRef`. Una vez en viewport, el efecto **sigue al target**:
```ts
useEffect(() => {
  if (isInView) spring.set(to);
}, [isInView, to, spring]);
```
Primera vez: anima `0→to`. Cambios posteriores de `to`: anima `valor-actual→to`. La ruta `prefers-reduced-motion` no cambia (ya renderiza `to` directo, reactivo).

## Test
Nuevo `AnimatedCounter.test.tsx` (mockea `motion/react`): asegura `spring.set(2)` al entrar en viewport y `spring.set(4)` al cambiar `to` — el 2º caso **fallaba** con el código anterior. ✅ tsc + eslint + 2 tests verdes.

Nota: al mergear, semantic-release publica un patch de `@jplannnou/gundo-ui`. gundo-ecommerce-ui puede bumpear para quitar el gate consumidor (opcional; el gate ya lo cubre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)