### PR TITLE
fix(useCamera): don't swallow play() rejection on iOS Safari (frozen-frame bug)

### DIFF
--- a/src/utils/useCamera.ts
+++ b/src/utils/useCamera.ts
@@ -55,7 +55,20 @@ export function useCamera(options: UseCameraOptions = {}): UseCameraResult {
       streamRef.current = stream;
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
-        await videoRef.current.play().catch(() => {});
+        try {
+          // Must be awaited (not swallowed): iOS Safari can reject play() when
+          // called outside a user gesture (autoplay policy, backgrounded PWA).
+          // If it rejects we fall through to the outer catch below instead of
+          // reporting `ready` over a frozen/black frame.
+          await videoRef.current.play();
+        } catch (playError) {
+          // Release the track we just opened so the camera indicator turns
+          // off while the error/start-button state is shown; a subsequent
+          // user tap on the start button re-requests a fresh stream.
+          stream.getTracks().forEach((t) => t.stop());
+          streamRef.current = null;
+          throw playError;
+        }
       }
       setReady(true);
     } catch (e) {


### PR DESCRIPTION
Wave 9. Adversarial-verified SOUND. **NO publicar/bumpear aún — coordinar** (otra sesión activa en gundo-ui).
useCamera: `play().catch(()=>{})` + `setReady(true)` incondicional → en iOS (autoplay/gesto) mostraba 'ready' sobre frame negro congelado y el scan loop poleaba canvases negros para siempre. Fix: await play() sin tragar; setReady(true) solo si resuelve; en reject detiene el track + setea error + deja el botón 'Enable camera' visible (el tap = gesto de retry). **API pública sin cambios** (autoStart sigue true, shape igual). Solo useCamera.ts. tsc+tests OK. 🤖 Generated with [Claude Code](https://claude.com/claude-code)