### PR TITLE
feat(PaywallUnified): opt-in add-on tier so Premium users aren't sold Premium

### DIFF
--- a/src/PaywallUnified.tsx
+++ b/src/PaywallUnified.tsx
@@ -25,6 +25,19 @@ export interface PaywallRoi {
   description?: string;
 }
 
+/**
+ * An add-on sold ON TOP of the base Premium plan (e.g. GUNDO Live, €4,99/mes).
+ * Providing it turns the comparison into three tiers — Free · Premium ·
+ * Premium + add-on — so a user who is ALREADY Premium is never told to
+ * "become Premium" for something Premium does not include.
+ */
+export interface PaywallAddonTier {
+  /** Third column header + CTA subject, e.g. `GUNDO Live`. */
+  label: string;
+  /** CTA when the user already has the base plan (default: `Añadir {label}`). */
+  ctaLabel?: string;
+}
+
 export interface PaywallUnifiedProps {
   /** What locked surface triggered this paywall */
   trigger: PaywallTrigger;
@@ -41,6 +54,20 @@ export interface PaywallUnifiedProps {
   onDismiss?: () => void;
   /** Replace the comparison matrix */
   featureMatrix?: PaywallFeatureRow[];
+  /**
+   * Opt-in third tier: an add-on that rides on top of Premium. When provided,
+   * the matrix renders a third column from each row's `addon` value. Omit it
+   * and the paywall stays exactly the Free-vs-Premium one.
+   */
+  addon?: PaywallAddonTier;
+  /**
+   * The user already pays for the base Premium plan. Only meaningful with
+   * `addon`: flips the header and CTA from "become Premium" to "add the
+   * add-on", since Premium is already theirs.
+   */
+  hasBasePlan?: boolean;
+  /** Override the primary CTA label entirely. */
+  ctaLabel?: string;
   /** Inline ROI tiles */
   roi?: PaywallRoi[];
   /** Social proof */
@@ -54,6 +81,8 @@ export interface PaywallFeatureRow {
   feature: string;
   free: string | boolean;
   premium: string | boolean;
+  /** Third-column value. Rendered only when an `addon` tier is provided. */
+  addon?: string | boolean;
   highlight?: boolean;
 }
 
@@ -153,6 +182,9 @@ export function PaywallUnified({
   subtitle,
   onDismiss,
   featureMatrix = defaultMatrix,
+  addon,
+  hasBasePlan = false,
+  ctaLabel,
   roi,
   testimonials,
   footer,
@@ -163,6 +195,16 @@ export function PaywallUnified({
   const savings = savingsPercent(pricing);
   const displayPrice =
     cycle === 'yearly' ? yearlyPerMonth(pricing) : pricing.monthly;
+
+  // With an add-on tier, someone who already pays for Premium is buying the
+  // add-on — not Premium. Anything else would be selling them what they have.
+  const sellingAddon = Boolean(addon) && hasBasePlan;
+  const primaryCta =
+    ctaLabel ??
+    (sellingAddon
+      ? (addon?.ctaLabel ?? `Añadir ${addon?.label}`)
+      : `Hacerme Premium${plan === 'plus' ? '+' : ''}`);
+  const premiumLabel = `Premium${plan === 'plus' ? '+' : ''}`;
 
   return (
     <section
@@ -198,8 +240,16 @@ export function PaywallUnified({
             className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold text-white"
             style={{ background: 'var(--ui-gradient)' }}
           >
-            Premium {plan === 'plus' ? '+' : ''}
+            {addon ? addon.label : `Premium ${plan === 'plus' ? '+' : ''}`}
           </span>
+          {sellingAddon && (
+            <span className="inline-flex items-center gap-1.5 rounded-full gu-bg-success-soft gu-text-success px-3 py-1 text-xs font-semibold">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                <path d="M2.5 6l2.5 2.5L9.5 3.5" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              Ya eres {premiumLabel}
+            </span>
+          )}
           <h2 id="paywall-title" className="text-2xl font-bold leading-tight">
             <span className="mr-2" aria-hidden="true">{copy.emoji}</span>
             {title ?? copy.title}
@@ -233,6 +283,11 @@ export function PaywallUnified({
           <span className="text-5xl font-bold tabular-nums">{formatEUR(displayPrice)}</span>
           <span className="pb-1.5 text-sm gu-text-text-secondary">
             /mes
+            {sellingAddon && (
+              <span className="ml-1 gu-text-text-muted">
+                · encima de tu {premiumLabel}
+              </span>
+            )}
             {cycle === 'yearly' && (
               <span className="ml-1 gu-text-text-muted">
                 (facturado {formatEUR(pricing.yearly)}/año)
@@ -272,9 +327,18 @@ export function PaywallUnified({
                 <th className="px-3 py-2 text-xs font-semibold">
                   Free
                 </th>
-                <th className="px-3 py-2 text-xs font-semibold gu-text-primary">
-                  Premium{plan === 'plus' ? '+' : ''}
+                <th
+                  className={`px-3 py-2 text-xs font-semibold ${
+                    addon ? '' : 'gu-text-primary'
+                  }`}
+                >
+                  {premiumLabel}
                 </th>
+                {addon && (
+                  <th className="px-3 py-2 text-xs font-semibold gu-text-primary">
+                    + {addon.label}
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody>
@@ -292,6 +356,11 @@ export function PaywallUnified({
                   <td className="px-3 py-2 text-center">
                     <Cell value={row.premium} />
                   </td>
+                  {addon && (
+                    <td className="px-3 py-2 text-center">
+                      <Cell value={row.addon ?? false} />
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>
@@ -324,7 +393,7 @@ export function PaywallUnified({
             className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl px-5 py-3 text-sm font-semibold text-white gu-shadow-shadow-md transition-transform hover:scale-[1.01] focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-focus-ring-color focus-visible:ring-offset-2 gu-fv-ring-offset-surface"
             style={{ background: 'var(--ui-gradient)' }}
           >
-            Hacerme Premium{plan === 'plus' ? '+' : ''}
+            {primaryCta}
           </button>
           {onDismiss && (
             <button

--- a/src/__tests__/PaywallUnified.test.tsx
+++ b/src/__tests__/PaywallUnified.test.tsx
@@ -37,4 +37,81 @@ describe('PaywallUnified', () => {
     );
     expect(screen.getAllByRole('button', { name: /Cerrar|Ahora no/ }).length).toBeGreaterThan(0);
   });
+
+  describe('add-on tier (opt-in third column)', () => {
+    const addon = { label: 'GUNDO Live' };
+    const matrix = [
+      { feature: 'Plan personalizado', free: true, premium: true, addon: true },
+      { feature: 'Báscula y anillo', free: false, premium: false, addon: true },
+    ];
+
+    it('stays a two-column Free-vs-Premium paywall when no addon is given', () => {
+      render(<PaywallUnified trigger="plan" onUpgrade={() => {}} pricing={pricing} />);
+      expect(screen.getByRole('button', { name: /Hacerme Premium/ })).toBeInTheDocument();
+      expect(screen.queryByText(/Ya eres Premium/)).not.toBeInTheDocument();
+      // Header row: Feature | Free | Premium — no third tier.
+      expect(screen.getAllByRole('columnheader')).toHaveLength(3);
+    });
+
+    it('renders the third column and its values when addon is given', () => {
+      render(
+        <PaywallUnified
+          trigger="plan"
+          onUpgrade={() => {}}
+          pricing={pricing}
+          featureMatrix={matrix}
+          addon={addon}
+        />,
+      );
+      expect(screen.getAllByRole('columnheader')).toHaveLength(4);
+      expect(screen.getByText(/\+ GUNDO Live/)).toBeInTheDocument();
+    });
+
+    it('sells the add-on (not Premium) to someone who already has Premium', () => {
+      const onUpgrade = vi.fn();
+      render(
+        <PaywallUnified
+          trigger="plan"
+          onUpgrade={onUpgrade}
+          pricing={pricing}
+          featureMatrix={matrix}
+          addon={addon}
+          hasBasePlan
+        />,
+      );
+      expect(screen.getByText(/Ya eres Premium/)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Hacerme Premium/ })).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /Añadir GUNDO Live/ }));
+      expect(onUpgrade).toHaveBeenCalledWith('yearly');
+    });
+
+    it('still routes a free user to Premium first', () => {
+      render(
+        <PaywallUnified
+          trigger="plan"
+          onUpgrade={() => {}}
+          pricing={pricing}
+          featureMatrix={matrix}
+          addon={addon}
+          hasBasePlan={false}
+        />,
+      );
+      expect(screen.getByRole('button', { name: /Hacerme Premium/ })).toBeInTheDocument();
+      expect(screen.queryByText(/Ya eres Premium/)).not.toBeInTheDocument();
+    });
+
+    it('honours an explicit ctaLabel override', () => {
+      render(
+        <PaywallUnified
+          trigger="plan"
+          onUpgrade={() => {}}
+          pricing={pricing}
+          addon={addon}
+          hasBasePlan
+          ctaLabel="Activar ahora"
+        />,
+      );
+      expect(screen.getByRole('button', { name: /Activar ahora/ })).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Problema

GUNDO Live es un **add-on de €4,99/mes encima de Premium**, pero `PaywallUnified` no puede expresarlo:

- `PaywallFeatureRow` sólo tiene `free` / `premium` → dos columnas, estructuralmente
- El CTA está **hardcodeado**: `Hacerme Premium{plan === 'plus' ? '+' : ''}`

Resultado en `/dispositivos`: a un usuario **que ya es Premium** se le muestra un banner "Hacerme Premium"… para venderle algo que la matriz ya le promete como incluido (`premium: true` en filas de wearables, lo cual es falso). Confunde y miente.

## Solución — tercer nivel opt-in

```ts
addon?: { label: string; ctaLabel?: string }  // activa la 3ª columna
PaywallFeatureRow.addon?: string | boolean    // valor de esa columna
hasBasePlan?: boolean                          // "✓ Ya eres Premium" + "Añadir {label}"
ctaLabel?: string                              // override explícito
```

- **Sin `addon`** → render idéntico al actual (Free vs Premium). Los paywalls de recetas/scanner/analytics **no se tocan**.
- **Con `addon`** → columna `+ GUNDO Live`; el precio se marca como "· encima de tu Premium".
- **`hasBasePlan`** → deja de vender Premium a quien ya lo tiene.

## Checks

- **858/858 tests** (114 files) verdes · `tsc --noEmit` limpio
- 5 casos nuevos: 3ª columna, CTA de add-on, ruta del usuario free, override, y **no-regresión de 2 columnas**
- Clases `gu-*` de `ui-classes.css` (regla 1 del CLAUDE.md), reusando las mismas que ya usa `Cell`

Consumidor: `gundo-ecommerce-ui` (`/dispositivos`) — bump tras el release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)