### PR TITLE
fix(Checkbox): make the unchecked box visible (WCAG 1.4.11)

### DIFF
--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -24,10 +24,14 @@ export function Checkbox({ label, checked = false, indeterminate = false, onChan
           className="peer sr-only"
           {...props}
         />
+        {/* Unchecked: --ui-border (white/10%) is ~1.3:1 on the dark surface — a
+            16px unfilled box was effectively invisible. --ui-text-muted clears
+            WCAG 1.4.11 (3.5:1 dark / 4.1:1 light) and the soft fill makes it
+            read as a control, matching Input's filled treatment. */}
         <span className={`flex items-center justify-center w-4 h-4 rounded border transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--ui-focus-ring-color)] peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-[var(--ui-surface)] ${
           checked || indeterminate
             ? 'gu-bg-primary gu-border-primary'
-            : 'gu-border-border bg-transparent peer-hover:border-[var(--ui-border-hover)]'
+            : 'gu-border-text-muted gu-bg-surface-hover peer-hover:border-[var(--ui-text-secondary)]'
         }`}>
           {checked && !indeterminate && (
             <Check className="w-3 h-3 text-white" strokeWidth={2.5} aria-hidden="true" />

--- a/src/__tests__/Checkbox.test.tsx
+++ b/src/__tests__/Checkbox.test.tsx
@@ -29,4 +29,25 @@ describe('Checkbox', () => {
     render(<Checkbox />);
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
   });
+
+  // The visible box is a sibling <span> — the real <input> is sr-only.
+  const box = (container: HTMLElement) =>
+    container.querySelector('input')?.nextElementSibling as HTMLElement;
+
+  it('gives the unchecked box a border that meets non-text contrast', () => {
+    // Regression: --ui-border is white/10% (~1.3:1 on the dark surface), which
+    // made a 16px unfilled checkbox effectively invisible. It must not come back.
+    const { container } = render(<Checkbox label="Test" />);
+    const cls = box(container).className;
+    expect(cls).toContain('gu-border-text-muted');
+    expect(cls).not.toContain('gu-border-border');
+    expect(cls).not.toContain('bg-transparent');
+  });
+
+  it('switches the unchecked box to the primary fill when checked', () => {
+    const { container } = render(<Checkbox label="Test" checked />);
+    const cls = box(container).className;
+    expect(cls).toContain('gu-bg-primary');
+    expect(cls).not.toContain('gu-border-text-muted');
+  });
 });

--- a/src/ui-classes.css
+++ b/src/ui-classes.css
@@ -30,6 +30,11 @@
 .gu-border-b-tooltip-bg{border-bottom-color:var(--ui-tooltip-bg)}
 .gu-border-border{border-color:var(--ui-border)}
 .gu-border-border-hover{border-color:var(--ui-border-hover)}
+/* Control outlines that must meet WCAG 1.4.11 non-text contrast (>=3:1).
+   --ui-border is white/10% — ~1.3:1 on the dark surface, invisible for a small
+   unfilled control like a checkbox. --ui-text-muted gives 3.5:1 dark / 4.1:1 light. */
+.gu-border-text-muted{border-color:var(--ui-text-muted)}
+.gu-border-text-secondary{border-color:var(--ui-text-secondary)}
 .gu-border-error{border-color:var(--ui-error)}
 .gu-border-info{border-color:var(--ui-info)}
 .gu-border-l-tooltip-bg{border-left-color:var(--ui-tooltip-bg)}


### PR DESCRIPTION
## Problema (reportado por JP desde el móvil)

En el sheet de consentimiento de GUNDO Live, **el cuadrado del check es casi invisible**. No es percepción: es contraste medible.

El estado sin marcar era:

```tsx
'gu-border-border bg-transparent'   // --ui-border = rgb(255 255 255 / 0.1)
```

Un borde de **blanco al 10%** sobre `--ui-surface` (#292E37) da **~1.3:1**. WCAG 2.1 AA **1.4.11 (non-text contrast)** exige **≥3:1** para el borde de un control. Sin relleno y a 16px, desaparece.

Era además **el control más débil de la familia**:

| Control | Borde sin marcar | Fondo |
|---|---|---|
| `Input` | `--ui-border` 1px | **`surface-hover`** (se ve por el relleno) |
| `RadioGroup` | `border-hover` (20%) **2px** | transparente |
| **`Checkbox`** | `--ui-border` (10%) **1px** | **transparente** ❌ |

## Fix

- `.gu-border-text-muted` / `.gu-border-text-secondary` nuevas en `ui-classes.css` (regla 1: nada de valores arbitrarios de Tailwind).
- Sin marcar → borde `--ui-text-muted` (**3.5:1 dark / 4.1:1 light** ✓) + el mismo relleno suave que usa `Input`, para que se lea como control. Hover sube a `--ui-text-secondary`.
- Marcado → sin cambios (relleno primary).

## Por qué no lo cazaron los tests

`axe-helper.ts` **deshabilita `color-contrast`** (las CSS custom properties no se resuelven en jsdom). Por eso añado **2 tests de regresión** que fijan la clase del borde.

- **860/860 tests** verdes · `tsc --noEmit` limpio
- Afecta a todos los consumidores (mejora transversal de a11y)

Follow-on detectado (fuera de este PR): `RadioGroup` está en ~1.7:1 — también por debajo de 3:1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)