### PR TITLE
feat(PaywallUnified): cycleMode inherited para add-ons que no eligen ciclo

### DIFF
--- a/src/PaywallUnified.tsx
+++ b/src/PaywallUnified.tsx
@@ -68,6 +68,21 @@ export interface PaywallUnifiedProps {
   hasBasePlan?: boolean;
   /** Override the primary CTA label entirely. */
   ctaLabel?: string;
+  /**
+   * Quien decide el ciclo de facturacion.
+   *
+   * - `choose` (default): lo elige el usuario → toggle Mensual/Anual, y el
+   *   precio grande es el del ciclo elegido.
+   * - `inherited`: NO se elige — lo hereda la suscripcion base. Es el caso de
+   *   un add-on: Stripe exige que todos los items de una suscripcion compartan
+   *   `interval`, asi que el add-on se factura al ciclo de la Premium que ya
+   *   tiene el usuario. Sin toggle (seria ficcion: no cambia nada de lo que se
+   *   cobra) y sin derivar `anual/12` (ese numero NO se cobra nunca).
+   *
+   * Con `inherited`, el argumento `cycle` de `onUpgrade` no significa nada:
+   * el ciclo real lo resuelve el backend leyendo la suscripcion base.
+   */
+  cycleMode?: 'choose' | 'inherited';
   /** Inline ROI tiles */
   roi?: PaywallRoi[];
   /** Social proof */
@@ -185,6 +200,7 @@ export function PaywallUnified({
   addon,
   hasBasePlan = false,
   ctaLabel,
+  cycleMode = 'choose',
   roi,
   testimonials,
   footer,
@@ -193,8 +209,15 @@ export function PaywallUnified({
   const [cycle, setCycle] = useState<PaywallBillingCycle>('yearly');
   const copy = triggerCopy[trigger];
   const savings = savingsPercent(pricing);
-  const displayPrice =
-    cycle === 'yearly' ? yearlyPerMonth(pricing) : pricing.monthly;
+  // Con el ciclo heredado no hay eleccion que mostrar: se enuncia el mensual
+  // real. Derivar `anual/12` aqui era exactamente el bug — pintaba un numero
+  // que no se cobra (49,90/12 = 4,16 mientras el cargo es 4,99).
+  const inheritsCycle = cycleMode === 'inherited';
+  const displayPrice = inheritsCycle
+    ? pricing.monthly
+    : cycle === 'yearly'
+      ? yearlyPerMonth(pricing)
+      : pricing.monthly;
 
   // With an add-on tier, someone who already pays for Premium is buying the
   // add-on — not Premium. Anything else would be selling them what they have.
@@ -259,24 +282,26 @@ export function PaywallUnified({
           </p>
         </header>
 
-        {/* Billing toggle */}
-        <div className="mt-6 inline-flex items-center rounded-full border gu-border-border gu-bg-surface-raised p-1">
-          {(['monthly', 'yearly'] as PaywallBillingCycle[]).map((c) => (
-            <button
-              key={c}
-              type="button"
-              onClick={() => setCycle(c)}
-              aria-pressed={cycle === c}
-              className={`rounded-full px-4 py-1.5 text-xs font-semibold transition-colors ${
-                cycle === c
-                  ? 'gu-bg-primary gu-text-surface'
-                  : 'gu-text-text-secondary gu-h-text-text'
-              }`}
-            >
-              {c === 'monthly' ? 'Mensual' : `Anual${savings > 0 ? ` · -${savings}%` : ''}`}
-            </button>
-          ))}
-        </div>
+        {/* Billing toggle — solo si el ciclo se elige (ver `cycleMode`). */}
+        {!inheritsCycle && (
+          <div className="mt-6 inline-flex items-center rounded-full border gu-border-border gu-bg-surface-raised p-1">
+            {(['monthly', 'yearly'] as PaywallBillingCycle[]).map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setCycle(c)}
+                aria-pressed={cycle === c}
+                className={`rounded-full px-4 py-1.5 text-xs font-semibold transition-colors ${
+                  cycle === c
+                    ? 'gu-bg-primary gu-text-surface'
+                    : 'gu-text-text-secondary gu-h-text-text'
+                }`}
+              >
+                {c === 'monthly' ? 'Mensual' : `Anual${savings > 0 ? ` · -${savings}%` : ''}`}
+              </button>
+            ))}
+          </div>
+        )}
 
         {/* Pricing */}
         <div className="mt-6 flex items-end gap-2">
@@ -288,7 +313,15 @@ export function PaywallUnified({
                 · encima de tu {premiumLabel}
               </span>
             )}
-            {cycle === 'yearly' && (
+            {/* Ciclo heredado: NO derivamos un precio/mes del anual — sería el
+                precio que NO se cobra. Se enuncian los dos reales. */}
+            {inheritsCycle && (
+              <span className="ml-1 gu-text-text-muted">
+                o {formatEUR(pricing.yearly)}/año, según el ciclo de tu{' '}
+                {premiumLabel}
+              </span>
+            )}
+            {!inheritsCycle && cycle === 'yearly' && (
               <span className="ml-1 gu-text-text-muted">
                 (facturado {formatEUR(pricing.yearly)}/año)
               </span>

--- a/src/__tests__/PaywallUnified.test.tsx
+++ b/src/__tests__/PaywallUnified.test.tsx
@@ -114,4 +114,60 @@ describe('PaywallUnified', () => {
       expect(screen.getByRole('button', { name: /Activar ahora/ })).toBeInTheDocument();
     });
   });
+
+  describe('cycleMode', () => {
+    // GUNDO Live: 4,99/mes o 49,90/año. Con el toggle en anual (el default) el
+    // header pintaba 49,90/12 = €4,16 — un precio que Stripe NUNCA cobra.
+    const live = { monthly: 4.99, yearly: 49.9, currency: 'EUR' as const };
+    const liveAddon = { label: 'GUNDO Live' };
+
+    it('choose (default): sigue mostrando el toggle', () => {
+      render(<PaywallUnified trigger="plan" onUpgrade={() => {}} pricing={live} />);
+      expect(screen.getByRole('button', { name: /Mensual/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Anual/ })).toBeInTheDocument();
+    });
+
+    it('inherited: no hay toggle — el ciclo no se elige', () => {
+      render(
+        <PaywallUnified
+          trigger="plan"
+          onUpgrade={() => {}}
+          pricing={live}
+          cycleMode="inherited"
+        />,
+      );
+      expect(screen.queryByRole('button', { name: /Mensual/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^Anual/ })).not.toBeInTheDocument();
+    });
+
+    it('inherited: muestra el mensual REAL, nunca el anual/12', () => {
+      render(
+        <PaywallUnified
+          trigger="plan"
+          onUpgrade={() => {}}
+          pricing={live}
+          cycleMode="inherited"
+        />,
+      );
+      expect(screen.getByText('€4.99')).toBeInTheDocument();
+      // El regression test que importa: 49,90/12 = 4,16 no puede volver.
+      expect(screen.queryByText('€4.16')).not.toBeInTheDocument();
+    });
+
+    it('inherited: enuncia el anual y de quién hereda el ciclo', () => {
+      render(
+        <PaywallUnified
+          trigger="plan"
+          onUpgrade={() => {}}
+          pricing={live}
+          addon={liveAddon}
+          hasBasePlan
+          cycleMode="inherited"
+        />,
+      );
+      expect(screen.getByText(/€49.90\/año, según el ciclo de tu/)).toBeInTheDocument();
+      // Y NO el copy de "facturado X/año", que afirma un ciclo concreto.
+      expect(screen.queryByText(/facturado/)).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## El bug

El header del paywall arranca en **anual** y deriva el precio con `yearly / 12`. Para GUNDO Live (€4,99/mes · €49,90/año) eso pinta **€4,16/mes** — un precio que Stripe **no cobra nunca**. El usuario ve €4,16, toca, y se le cobra €4,99.

## Por qué el toggle sobra (y no había que cablearlo)

Para un add-on el ciclo **no se elige**: Stripe exige que todos los ítems de una suscripción compartan `interval`, así que el add-on se factura al ciclo de la Premium que el usuario ya tiene. El backend lo resuelve leyendo la suscripción base (`stripe.gateway.ts`: `subscription.items.data[0].price.recurring.interval`).

O sea: el toggle no cambia nada de lo que se cobra. Era una elección ficticia. La primera lectura de este bug fue "el CTA ignora el ciclo elegido, hay que pasarlo" — es al revés: **hay que quitar la elección**.

## El cambio

`cycleMode="inherited"` — **opt-in**, default `choose` → cero cambio para los llamadores actuales.

Con `inherited`: sin toggle, el precio grande es el **mensual real**, y se enuncian los dos ("€4,99/mes o €49,90/año, según el ciclo de tu Premium") en vez de afirmar un ciclo que el componente no conoce.

Es genérico, no ad-hoc: cualquier add-on sobre una suscripción tiene la misma restricción (`connected_cgm` es el siguiente).

## Tests

13/13. Los 4 nuevos cubren: el toggle sigue en `choose`; desaparece en `inherited`; se muestra €4,99 y **nunca** €4,16 (el regression que importa); y no se afirma "facturado X/año".

## Consumidor

`gundo-ecommerce-ui` → `GundoLivePaywall.tsx`, en PR aparte una vez semantic-release publique esto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)