### PR TITLE
test(visual): serve a built harness so there is no unstyled frame to record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ dist/
 
 # a11y full sweep report (generated)
 e2e/a11y/a11y-full-report.json
+
+# Playwright run output (generated). Baselines live in e2e/visual/__snapshots__
+# and ARE tracked — these two only hold the actual/diff of a failing run.
+test-results/
+playwright-report/

--- a/e2e/visual/vite.config.ts
+++ b/e2e/visual/vite.config.ts
@@ -7,6 +7,22 @@ export default defineConfig({
     port: 4173,
     strictPort: true,
   },
+  // The visual suite serves a BUILT harness, not the dev server (TD-011). In dev
+  // every `import './ui-classes.css'` is injected by JS after first paint, so
+  // there is a window where components render unstyled — and `toHaveScreenshot`
+  // stops at the first frame that MATCHES, so a baseline recorded in that window
+  // matches an early broken frame forever (that is exactly what happened, see
+  // TD-010). A build emits the CSS as a blocking <link>: no unstyled window to
+  // record. Keep this in sync with playwright.config.ts's webServer.
+  preview: {
+    port: 4173,
+    strictPort: true,
+  },
+  build: {
+    // Deterministic pixels beat byte-size here: minification can shift text
+    // rendering, and the baselines are compared at 100px tolerance.
+    minify: false,
+  },
   resolve: {
     alias: {
       '@gundo/ui': resolve(__dirname, '../../src'),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,8 +84,16 @@ export default defineConfig({
 
   /* ─── Local dev server for visual tests ─────────────────────── */
   webServer: {
-    command: 'npx vite --config e2e/visual/vite.config.ts',
+    // BUILD + preview, never the dev server (TD-011). Dev injects component CSS
+    // via JS after first paint, leaving a window where everything renders
+    // unstyled — and since toHaveScreenshot stops at the first frame that
+    // matches, a baseline captured in that window keeps matching broken frames
+    // forever. That is how 41 of 60 baselines ended up wrong (TD-010). A build
+    // ships the CSS as a blocking <link>, so there is no unstyled frame to catch.
+    command:
+      'npx vite build --config e2e/visual/vite.config.ts && npx vite preview --config e2e/visual/vite.config.ts',
     port: 4173,
+    timeout: 180_000, // the build runs before the port opens
     reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
Closes TD-011, the root cause left open by #72.

#72 regenerated the 41 poisoned baselines, but it didn't close the window that poisoned them. The harness runs on the Vite **dev** server, where `import './ui-classes.css'` is injected by JS after first paint — so components render unstyled for a moment. Since `toHaveScreenshot` **stops at the first frame that matches**, any baseline captured in that window keeps matching early broken frames forever. Regenerate on an unlucky run and we're back to a suite that passes while asserting nothing.

A **build** emits the CSS as a blocking `<link>`:

```
dist/index.html
<link rel="stylesheet" crossorigin href="/assets/index-BhM-rQCq.css">   ← 21.46 kB, all component CSS
```

There is no unstyled frame left to capture. `minify: false` because deterministic pixels matter more than bytes here.

## The check that matters

**The baselines are untouched.** If the built harness renders what `--update-snapshots` captured, `visual` passes as-is — which is the proof that the "stable" render and the "built" render are the same thing, i.e. the real one. If it went red, it would mean #72's baselines were wrong too.

Also ignores `test-results/` and `playwright-report/` — run output, 45 untracked files locally. The tracked baselines live in `e2e/visual/__snapshots__`.