### PR TITLE
fix(theme): TD-013 — verde del gradiente de marca a WCAG AA (dark + light)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@
 --ui-tertiary: #24495A;  --ui-tertiary-hover: #1e3d4c;
 --ui-tertiary-soft: rgb(36 73 90 / 0.15);
 
-/* Brand gradient */
---ui-gradient: linear-gradient(135deg, #24495A, #409C35);
+/* Brand gradient — green end darkened for WCAG AA (white ink), TD-013 */
+--ui-gradient: linear-gradient(135deg, #24495A, #36852C);
 
 /* Surfaces — brandbook charcoal (dark-first) */
 --ui-surface: #292E37;

--- a/src/PaywallUnified.tsx
+++ b/src/PaywallUnified.tsx
@@ -258,13 +258,13 @@ export function PaywallUnified({
         {/* Header */}
         <header className="flex flex-col items-start gap-3">
           <span
-            // text-white intencional, NO cambiar a gu-text-surface (TD-009): el
-            // fondo es --ui-gradient, que NO voltea con el tema, así que la tinta
-            // tampoco debe. Medido sobre el extremo azul #24495A: blanco 9.65:1,
-            // surface-dark 1.41:1 — invisible. El blanco es lo correcto aquí.
-            // Pendiente aparte: sobre el extremo verde #409C35 el blanco da
-            // 3.49:1, corto para AA normal (4.5:1) — se arregla oscureciendo el
-            // gradiente, que es decisión de marca.
+            // text-white intencional, NO cambiar a gu-text-surface (TD-009): en
+            // ambos temas el gradiente arranca en un extremo oscuro (azul #24495A
+            // dark / verde profundo #08563E light) donde surface-dark es invisible
+            // (1.41:1) y solo el blanco funciona. El extremo verde se oscureció
+            // (dark #36852C, light #428417) para que el blanco clave AA normal
+            // (4.6:1) en todo el gradiente — TD-013 resuelto (antes 3.49:1 dark /
+            // 2.15:1 light).
             className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold text-white"
             style={{ background: 'var(--ui-gradient)' }}
           >

--- a/src/__tests__/semantic-ink.test.tsx
+++ b/src/__tests__/semantic-ink.test.tsx
@@ -13,8 +13,11 @@ import { FloatingActionButton } from '../FloatingActionButton';
  * #f87171 = 2.77:1. --ui-surface flips with the theme, so it clears AA on both
  * grounds (primary: 6.35:1 dark / 8.71:1 light).
  *
- * The exception is --ui-gradient (PaywallUnified): it does NOT flip, so its ink
- * must not either — surface-dark on the gradient's blue end is 1.41:1.
+ * The exception is --ui-gradient (PaywallUnified): it keeps WHITE ink in both
+ * themes. Each theme's gradient starts on a dark end (blue #24495A dark / deep
+ * green #08563E light) where surface-dark is invisible (1.41:1) and only white
+ * works; the green end is darkened (dark #36852C, light #428417) so white also
+ * clears AA there (4.6:1). TD-013.
  */
 describe('semantic backgrounds ink with the theme surface, not white', () => {
   it('Pagination: the active page', () => {

--- a/src/theme.css
+++ b/src/theme.css
@@ -27,8 +27,12 @@
   --ui-tertiary-hover: #1e3d4c;
   --ui-tertiary-soft: rgb(36 73 90 / 0.15);
 
-  /* Brand gradient */
-  --ui-gradient: linear-gradient(135deg, #24495A, #409C35);
+  /* Brand gradient. Ink on top is always white (PaywallUnified/MagicLinkAuth):
+     the blue start #24495A needs it (surface-dark is 1.41:1 there). The green
+     end is #36852C — darkened from the old #409C35 so white clears WCAG AA
+     normal (4.6:1 vs the old 3.49:1) across the whole sweep. Do NOT restore a
+     brighter green: white text on it fails AA. TD-013. */
+  --ui-gradient: linear-gradient(135deg, #24495A, #36852C);
 
   /* Surface colors — brandbook charcoal (backgrounds) */
   --ui-surface: #292E37;
@@ -214,7 +218,10 @@
   --ui-tertiary-hover: #5ab322;
   --ui-tertiary-soft: rgb(103 199 40 / 0.1);
 
-  --ui-gradient: linear-gradient(135deg, #08563E, #67C728);
+  /* Green end darkened from the old #67C728 (white was 2.15:1 — worse than the
+     dark theme) to #428417 so white clears WCAG AA normal (4.6:1). See the dark
+     theme's gradient note. TD-013. */
+  --ui-gradient: linear-gradient(135deg, #08563E, #428417);
 
   /* Surface — brandbook warm off-white */
   --ui-surface: #F2F4F3;


### PR DESCRIPTION
## Qué

Texto blanco sobre `--ui-gradient` fallaba **WCAG AA normal (4.5:1)** en el extremo verde, en **ambos temas**:

| tema | verde antes | blanco | | verde ahora | blanco |
|---|---|---|---|---|---|
| dark `:root` | `#409C35` | **3.49:1** ✗ | → | `#36852C` | **4.62:1** ✓ |
| light `.theme-light` | `#67C728` | **2.15:1** ✗✗ | → | `#428417` | **4.62:1** ✓ |

El light no estaba documentado en TD-013 y era **peor** que el dark — lo destapó `semantic-ink.test` al medir blanco sobre `#67C728`.

## Por qué oscurecer el verde y no la tinta

El blanco es forzado: el extremo oscuro de cada tema (azul `#24495A` dark / verde profundo `#08563E` light) da 1.41:1 con `surface-dark` — invisible. Solo el blanco funciona ahí. Así que el único fix es bajar la luminancia del verde.

Hexes calculados **escalando la luminancia en espacio lineal** (chromaticity/hue preservado) hasta clavar ~4.6:1. Es el **literal del gradiente**: `--ui-primary` (botones/links/charts) **no se toca**.

## Alcance / impacto

- Extremos azul y verde-oscuro **intactos** (9.65 / 8.71).
- Dark: ajuste sutil. **Light: shift mayor** (de lima brillante a verde profundo) por partir de 2.15:1.
- Corrige comentarios en `PaywallUnified` y `semantic-ink.test` que afirmaban erróneamente que el gradiente *"no voltea con el tema"* (sí voltea: hay override `.theme-light`).

## Verificación

- `tsc --noEmit` limpio.
- 83 tests verdes (`semantic-ink` + `contrast` + `a11y` axe-core).
- Contraste calculado con script WCAG (white-on-hex), ambos clavan 4.62:1.
- Preview visual before/after (dark + light) revisado.

Cierra TD-013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)