### PR TITLE
fix(cookies): que rechazar pese lo mismo que aceptar, y en tu idioma

### DIFF
--- a/src/CookieBanner.tsx
+++ b/src/CookieBanner.tsx
@@ -32,6 +32,18 @@ export interface CookieBannerProps {
   /** Position (default: 'bottom') */
   position?: 'bottom' | 'bottom-left' | 'bottom-right';
   className?: string;
+  /**
+   * Textos de los botones. Estaban cosidos en español dentro de la librería,
+   * así que en una app con siete idiomas el usuario alemán leía "Aceptar
+   * todas". El consentimiento tiene que pedirse en un lenguaje claro y
+   * comprensible para quien lo da (RGPD art. 12.1) y en Cataluña además debe
+   * estar disponible en catalán (Codi de consum, art. 128-1). El defecto sigue
+   * en español para no romper a quien no los pase.
+   */
+  acceptLabel?: string;
+  rejectLabel?: string;
+  savePreferencesLabel?: string;
+  customizeLabel?: string;
 }
 
 const DEFAULT_CATEGORIES: CookieCategory[] = [
@@ -39,6 +51,13 @@ const DEFAULT_CATEGORIES: CookieCategory[] = [
   { id: 'analytics', label: 'Analíticas', description: 'Nos ayudan a entender cómo interactúas con el sitio.' },
   { id: 'marketing', label: 'Marketing', description: 'Usadas para mostrarte publicidad relevante.' },
 ];
+
+/**
+ * Lo que aceptar y rechazar comparten: tamaño, grosor y borde. Solo el color
+ * los distingue, que es lo que permite que ninguno pese más que el otro.
+ */
+const SAME_BUTTON =
+  'flex-1 rounded-lg border px-4 py-2 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary';
 
 const positionClasses: Record<string, string> = {
   bottom: 'bottom-0 left-0 right-0 mx-4 mb-4 sm:mx-auto sm:max-w-2xl',
@@ -58,6 +77,10 @@ export function CookieBanner({
   description = 'Usamos cookies para mejorar tu experiencia y analizar el tráfico del sitio. Puedes aceptar todas o personalizar tus preferencias.',
   privacyPolicyUrl,
   privacyPolicyLabel = 'Política de privacidad',
+  acceptLabel = 'Aceptar todas',
+  rejectLabel = 'Solo necesarias',
+  savePreferencesLabel = 'Guardar preferencias',
+  customizeLabel,
   variant = 'simple',
   position = 'bottom',
   className = '',
@@ -129,21 +152,28 @@ export function CookieBanner({
           </ul>
         )}
 
-        {/* Actions */}
+        {/* Actions
+            Aceptar iba RELLENO y rechazar en contorno, con lo que aceptar
+            pesaba mucho más en la mirada. La guía de cookies de la AEPD pide
+            que rechazar sea tan accesible y VISIBLE como aceptar (y el CEPD lo
+            trata como patrón engañoso), así que los dos comparten ahora tamaño,
+            grosor, borde y relleno; solo cambia el color. `SAME_BUTTON` existe
+            para que un cambio de estilo no pueda volver a desequilibrarlos sin
+            que se note. */}
         <div className="flex flex-wrap items-center gap-2">
           <button
             type="button"
             onClick={onAcceptAll}
-            className="flex-1 rounded-lg gu-bg-primary px-4 py-2 text-xs font-semibold gu-text-surface transition-colors gu-h-bg-primary-hover focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary"
+            className={`${SAME_BUTTON} gu-bg-primary gu-text-surface gu-border-primary gu-h-bg-primary-hover`}
           >
-            Aceptar todas
+            {acceptLabel}
           </button>
           <button
             type="button"
             onClick={onRejectAll}
-            className="flex-1 rounded-lg border gu-border-border px-4 py-2 text-xs font-semibold gu-text-text transition-colors gu-h-bg-surface-hover focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary"
+            className={`${SAME_BUTTON} gu-bg-surface-hover gu-text-text gu-border-border gu-h-bg-surface-hover`}
           >
-            Solo necesarias
+            {rejectLabel}
           </button>
           {variant === 'detailed' && (
             <>
@@ -153,7 +183,7 @@ export function CookieBanner({
                   onClick={() => onSavePreferences?.(prefs)}
                   className="w-full rounded-lg border gu-border-primary px-4 py-2 text-xs font-semibold gu-text-primary transition-colors gu-h-bg-primary-soft focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary"
                 >
-                  Guardar preferencias
+                  {savePreferencesLabel}
                 </button>
               ) : (
                 <button
@@ -161,7 +191,7 @@ export function CookieBanner({
                   onClick={() => setShowDetails(true)}
                   className="w-full text-xs gu-text-text-muted underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary rounded"
                 >
-                  Personalizar
+                  {customizeLabel ?? 'Personalizar'}
                 </button>
               )}
             </>

--- a/src/__tests__/CookieBanner.test.tsx
+++ b/src/__tests__/CookieBanner.test.tsx
@@ -95,3 +95,49 @@ describe('CookieBanner', () => {
     expect(screen.getByRole('link', { name: 'Política de privacidad' })).toBeInTheDocument();
   });
 });
+
+describe('simetría del consentimiento', () => {
+  const props = {
+    open: true,
+    onAcceptAll: () => {},
+    onRejectAll: () => {},
+  };
+
+  /**
+   * La guía de cookies de la AEPD pide que rechazar sea tan accesible y visible
+   * como aceptar; el CEPD trata lo contrario como patrón engañoso. Aceptar iba
+   * relleno y rechazar en contorno, así que aceptar pesaba mucho más.
+   */
+  it('aceptar y rechazar comparten tamaño, grosor y borde', () => {
+    render(<CookieBanner {...props} />);
+
+    const aceptar = screen.getByRole('button', { name: 'Aceptar todas' });
+    const rechazar = screen.getByRole('button', { name: 'Solo necesarias' });
+
+    const compartido = ['flex-1', 'rounded-lg', 'border', 'px-4', 'py-2', 'text-xs', 'font-semibold'];
+    for (const clase of compartido) {
+      expect(aceptar.className).toContain(clase);
+      expect(rechazar.className).toContain(clase);
+    }
+  });
+
+  it('ninguno de los dos se queda sin relleno', () => {
+    // Contorno contra relleno es justo el desequilibrio que había.
+    render(<CookieBanner {...props} />);
+
+    expect(screen.getByRole('button', { name: 'Aceptar todas' }).className).toMatch(/gu-bg-/);
+    expect(screen.getByRole('button', { name: 'Solo necesarias' }).className).toMatch(/gu-bg-/);
+  });
+
+  it('los textos se pueden traducir; el defecto sigue en español', () => {
+    // Estaban cosidos en español dentro de la librería: en una app de siete
+    // idiomas, el usuario alemán leía "Aceptar todas" (RGPD art. 12.1).
+    const { unmount } = render(<CookieBanner {...props} />);
+    expect(screen.getByRole('button', { name: 'Aceptar todas' })).toBeTruthy();
+    unmount();
+
+    render(<CookieBanner {...props} acceptLabel="Alle akzeptieren" rejectLabel="Nur notwendige" />);
+    expect(screen.getByRole('button', { name: 'Alle akzeptieren' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Nur notwendige' })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Dos defectos del banner de consentimiento, los dos visibles en **cualquier frontend** que use la librería. Salieron de mirar una captura de `/axa` con el ojo puesto en otra cosa.

## Simetría

**"Aceptar todas" iba relleno y "Solo necesarias" en contorno**, así que aceptar pesaba mucho más en la mirada.

La [guía de cookies de la AEPD](https://www.aepd.es/documento/guia-cookies.pdf) pide que rechazar sea **tan accesible y visible** como aceptar, y el CEPD trata lo contrario como patrón engañoso. Los dos botones comparten ahora tamaño, grosor, borde y relleno; solo cambia el color.

Se extrae a `SAME_BUTTON` para que un retoque de estilo no pueda volver a desequilibrarlos sin que se note.

## Idioma

**Los textos de los botones estaban cosidos en español dentro de la librería.** En una app con siete idiomas eso significa que el título y la descripción llegan traducidos y **justo debajo el usuario alemán lee "Aceptar todas"**.

El consentimiento hay que pedirlo en un lenguaje claro y comprensible para quien lo da (**RGPD art. 12.1**), y en Cataluña además disponible en catalán (**Codi de consum, art. 128-1**).

Se abren cuatro props. **El defecto sigue en español**, así que ningún consumidor se rompe al actualizar — quien no las pase se queda como está.

## Verificación

Tres tests nuevos, **verificados fallando** antes del cambio: que las dos acciones comparten las clases de peso, que ninguna se queda sin relleno, y que los textos se pueden traducir conservando el defecto. 13/13 en el archivo, `tsc` limpio.

## Después de mergear

Hay que **publicar una versión** para que `gundo-ecommerce-ui` pueda pasar los textos traducidos — las siete traducciones ya están escritas y esperando en su lado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
