### PR TITLE
fix(a11y): la matriz del paywall se anunciaba vacía (aria-prohibited-attr ×15)

### DIFF
--- a/src/PaywallUnified.tsx
+++ b/src/PaywallUnified.tsx
@@ -158,10 +158,31 @@ function savingsPercent(pricing: PaywallPricing): number {
 
 /* ─── Row renderer ───────────────────────────────────────────────────── */
 
+/**
+ * Celda de la matriz de comparación.
+ *
+ * POR QUÉ LLEVAN `role="img"`:
+ * El sí/no se dibuja con un tick o una cruz en SVG, y el SVG va `aria-hidden`
+ * porque la forma no dice nada por sí sola: el significado lo pone el
+ * `aria-label` del contenedor. Pero un `<span>` pelado mapea al rol `generic`,
+ * que NO admite nombre accesible — el lector de pantalla DESCARTA ese
+ * `aria-label` y la celda se anuncia vacía. Con `aria-hidden` dentro y una
+ * etiqueta que no cuenta fuera, la fila entera quedaba muda: quien la
+ * escuchara no podía saber si la función estaba incluida o no.
+ *
+ * `role="img"` es el rol de "una imagen cuyo contenido es una unidad", admite
+ * nombre accesible y hace que la etiqueta se anuncie. Medido con axe en
+ * producción (pantalla de dispositivos, desktop, 2026-08-02): 15 nodos
+ * `aria-prohibited-attr` serios, todos de estas dos celdas.
+ *
+ * OJO: quitar el `aria-label` NO era el arreglo — dejaría la celda sin nombre,
+ * que es peor. El arreglo es darle al elemento un rol que sí pueda llevarlo.
+ */
 function Cell({ value }: { value: string | boolean }) {
   if (value === true) {
     return (
       <span
+        role="img"
         className="inline-flex h-5 w-5 items-center justify-center rounded-full gu-bg-success-soft gu-text-success"
         aria-label="Incluido"
       >
@@ -174,6 +195,7 @@ function Cell({ value }: { value: string | boolean }) {
   if (value === false) {
     return (
       <span
+        role="img"
         className="inline-flex h-5 w-5 items-center justify-center rounded-full gu-bg-surface-hover gu-text-text-muted"
         aria-label="No incluido"
       >

--- a/src/__tests__/aria-prohibida.test.ts
+++ b/src/__tests__/aria-prohibida.test.ts
@@ -1,0 +1,161 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guarda de `aria-prohibited-attr` (axe, serio).
+ *
+ * QUÉ VIGILA
+ * Un `aria-label`/`aria-labelledby` puesto en un elemento cuyo rol implícito NO
+ * admite nombre accesible. Un `<span>`/`<div>`/`<p>` pelado mapea al rol
+ * `generic`, y el lector de pantalla DESCARTA la etiqueta: el elemento se
+ * anuncia vacío. Cuando además el contenido va `aria-hidden` (un icono SVG),
+ * el resultado es un control mudo — parece etiquetado y no lo está.
+ *
+ * POR QUÉ EXISTE
+ * `PaywallUnified` pintaba el sí/no de la matriz de comparación con dos
+ * `<span aria-label>` y un SVG oculto dentro. Medido con axe en producción
+ * (pantalla de dispositivos, desktop, 2026-08-02): 15 nodos serios de esas dos
+ * celdas. Ningún test lo veía, porque el DS no tenía ninguna guarda de ARIA
+ * sobre su propio código fuente.
+ *
+ * EL ARREGLO NUNCA ES QUITAR LA ETIQUETA: eso deja el elemento sin nombre, que
+ * es peor. Es darle un rol que sí pueda llevarla (`img`, `group`, `status`…) o
+ * usar el elemento semántico de verdad (`<button>` en vez de un `<div>` con
+ * onClick).
+ *
+ * DEUDA CONOCIDA
+ * El barrido del 2026-08-02 encontró 24 casos en 16 archivos. Este PR arregla
+ * los 2 medidos (`PaywallUnified`); los otros 22 quedan CONGELADOS abajo. La
+ * lista es un techo, no un permiso: sirve para que no aparezcan nuevos mientras
+ * se van bajando. Al arreglar uno, BORRAR su archivo de aquí — si sigue en la
+ * lista sin violaciones, el test también falla.
+ */
+const DEUDA_CONOCIDA = new Set([
+  'Avatar.tsx',
+  'ContactCard.tsx',
+  'DataChip.tsx',
+  'DetailHeader.tsx',
+  'DetailTabs.tsx',
+  'FloatingActionButton.tsx',
+  'LoadingSkeletonVariants.tsx',
+  'MealCard.tsx',
+  'NotificationCard.tsx',
+  'ProductCard.tsx',
+  'ProfileHeader.tsx',
+  'SenderIdentity.tsx',
+  'UserMenu.tsx',
+  'motion/TypeWriter.tsx',
+  'widget/ChatSection.tsx',
+  'widget/GundoWidget.tsx',
+]);
+
+/** Elementos cuyo rol implícito es `generic`: no admiten nombre accesible. */
+const SIN_NOMBRE = ['span', 'div', 'p'];
+
+// Se leen las fuentes por el bundler (no por `node:fs`): el DS es una librería
+// de navegador y no lleva @types/node, así que un `readFileSync` rompería
+// `pnpm typecheck` aunque los tests pasaran.
+const FUENTES = import.meta.glob('../**/*.tsx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+/**
+ * Los atributos de una etiqueta de apertura, desde `<tag` hasta su `>`.
+ *
+ * No vale un `[^>]*`: un `style={{ background: score >= 75 ? … }}` mete `>`
+ * DENTRO del atributo y la etiqueta se cortaba por la mitad, así que el
+ * `aria-label` que venía después quedaba fuera del match y la violación pasaba
+ * invisible (fue el caso de ContactCard). Hay que contar llaves y comillas para
+ * saber cuál es el `>` que de verdad cierra.
+ */
+function atributosDe(fuente: string, desde: number): string | null {
+  let llaves = 0;
+  let comilla: string | null = null;
+  for (let i = desde; i < fuente.length; i++) {
+    const c = fuente[i];
+    if (comilla) {
+      if (c === comilla) comilla = null;
+    } else if (c === '"' || c === "'" || c === '`') {
+      comilla = c;
+    } else if (c === '{') {
+      llaves++;
+    } else if (c === '}') {
+      llaves--;
+    } else if (c === '>' && llaves === 0) {
+      return fuente.slice(desde, i);
+    }
+  }
+  return null;
+}
+
+function violaciones(fuente: string): string[] {
+  const encontradas: string[] = [];
+  const re = new RegExp(`<(${SIN_NOMBRE.join('|')})(?=[\\s/>])`, 'g');
+  for (const m of fuente.matchAll(re)) {
+    const atributos = atributosDe(fuente, m.index + m[0].length);
+    if (atributos === null) continue;
+    const etiquetado = /\saria-label(ledby)?\s*=/.test(atributos);
+    const tieneRol = /\srole\s*=/.test(atributos);
+    if (etiquetado && !tieneRol) {
+      encontradas.push(`<${m[1]}${atributos.replace(/\s+/g, ' ').slice(0, 90)}>`);
+    }
+  }
+  return encontradas;
+}
+
+describe('aria-prohibited-attr · el DS no etiqueta elementos sin rol', () => {
+  const archivos = Object.entries(FUENTES)
+    .map(([ruta, fuente]) => ({
+      id: ruta.replace(/^\.\.\//, ''),
+      hallazgos: violaciones(fuente),
+    }))
+    .filter((a) => !a.id.startsWith('__tests__/'));
+
+  it('encuentra archivos que revisar (el escáner no está roto)', () => {
+    // Sin esto, un escáner que no matchea nada dejaría todo en verde.
+    expect(archivos.length).toBeGreaterThan(50);
+  });
+
+  for (const { id, hallazgos } of archivos) {
+    if (DEUDA_CONOCIDA.has(id)) continue;
+    it(`${id} no pone aria-label en un elemento sin rol`, () => {
+      expect(
+        hallazgos,
+        `${id} etiqueta un elemento cuyo rol implícito es \`generic\`: el ` +
+          `lector de pantalla descarta la etiqueta y lo anuncia vacío. No la ` +
+          `quites — dale el rol correcto (img/group/status) o usa el elemento ` +
+          `semántico (<button>, <nav>…).`,
+      ).toEqual([]);
+    });
+  }
+
+  it('la lista de deuda no se queda con archivos ya arreglados', () => {
+    const conHallazgos = new Set(
+      archivos.filter((a) => a.hallazgos.length > 0).map((a) => a.id),
+    );
+    const yaLimpios = [...DEUDA_CONOCIDA].filter((id) => !conHallazgos.has(id));
+    expect(
+      yaLimpios,
+      `Estos archivos ya no violan la regla: bórralos de DEUDA_CONOCIDA para ` +
+        `que la guarda los proteja de aquí en adelante.`,
+    ).toEqual([]);
+  });
+
+  it('PaywallUnified anuncia el sí/no de la matriz', () => {
+    // El caso medido: 15 nodos serios. Las dos celdas van con `role="img"`
+    // para que su `aria-label` sea válido y se anuncie.
+    const fuente = FUENTES['../PaywallUnified.tsx'];
+    expect(fuente, 'no se encuentra PaywallUnified.tsx').toBeTruthy();
+    for (const etiqueta of ['Incluido', 'No incluido']) {
+      const at = fuente.indexOf(`aria-label="${etiqueta}"`);
+      expect(at, `falta la celda "${etiqueta}"`).toBeGreaterThan(-1);
+      const celda = fuente.slice(Math.max(0, at - 400), at);
+      expect(
+        celda.includes('role="img"'),
+        `la celda "${etiqueta}" perdió su role="img" y vuelve a anunciarse vacía`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Qué medí

`axe-core` contra **producción** (`ultrapersonalizacion.gundo.life`, pantalla de dispositivos, desktop 1280×800, entrando por `/axa` para que el tenant y el país queden fijados):

```
aria-prohibited-attr · serious · 15 nodos
```

Los **15** salen de un solo sitio: las dos celdas de `Cell` en `PaywallUnified` (la matriz de comparación Free · Premium · GUNDO Live), repetidas por fila y columna.

## Por qué estaba mal

El sí/no se dibuja con un tick o una cruz en SVG. El SVG va `aria-hidden` —correcto, la forma sola no significa nada— y el significado lo ponía un `aria-label` en el `<span>` contenedor.

Pero **un `<span>` pelado mapea al rol `generic`, que no admite nombre accesible**: el lector de pantalla descarta ese `aria-label`. Contenido oculto dentro + etiqueta que no cuenta fuera = **la celda se anuncia vacía**. Quien escuchara la tabla no podía saber si la función estaba incluida — que es lo único que esa tabla comunica.

## El arreglo

**No es quitar la etiqueta** (dejaría la celda sin nombre, que es peor). Es darle al elemento un rol que sí pueda llevarla:

```diff
 <span
+  role="img"
   className="… gu-bg-success-soft gu-text-success"
   aria-label="Incluido"
 >
```

`role="img"` = "una imagen cuyo contenido es una unidad". Admite nombre accesible, y el SVG interno sigue `aria-hidden`.

## Guarda mecánica

`src/__tests__/aria-prohibida.test.ts` escanea las fuentes del DS y falla si un `<span>`/`<div>`/`<p>` **sin `role`** lleva `aria-label`/`aria-labelledby`.

Dos detalles que la hacen fiable:
- **El escáner cuenta llaves y comillas** en vez de cortar en el primer `>`. Un `style={{ background: score >= 75 ? … }}` mete un `>` dentro del atributo y partía la etiqueta por la mitad — así se me escapaba el caso de `ContactCard` en la primera versión.
- **Verificada en negativo**: quitando el `role="img"` a mano, el test falla (2 fallos). No es una guarda vacía.

## 🔴 Deuda que destapa el barrido — 24 casos en 16 archivos

Este PR arregla **los 2 medidos**. Los otros **22 quedan congelados** en `DEUDA_CONOCIDA`, para que no aparezcan nuevos mientras se bajan. La lista se auto-verifica: si un archivo listado deja de violar la regla, el test exige quitarlo de la lista.

| Archivo | Nodos | Arreglo sugerido |
|---|---|---|
| `LoadingSkeletonVariants.tsx` | 4 | `role="status"` (ya llevan `aria-busy`) |
| `SenderIdentity.tsx` | 3 | `role="group"` |
| `ProductCard.tsx` | 2 | `role="img"` (badge de score) |
| `Avatar.tsx` | 1 | `role="img"` (fallback de iniciales) |
| `MealCard.tsx`, `DetailHeader.tsx`, `ContactCard.tsx`, `ChatSection.tsx` | 4 | `role="img"` (badges de score) |
| `DetailTabs.tsx` | 1 | `role="img"` (emoji 🔒) |
| `DataChip.tsx` | 1 | `role="img"` |
| `NotificationCard.tsx` | 1 | `role="img"` o `<VisuallyHidden>` |
| `FloatingActionButton.tsx`, `GundoWidget.tsx` | 2 | `role="status"` o plegar el contador en el `aria-label` del botón |
| `ProfileHeader.tsx` | 1 | `role="group"` |
| `TypeWriter.tsx` | 1 | `role="img"` o `<VisuallyHidden>` con el texto completo |
| **`UserMenu.tsx`** | 1 | **`<div onClick>` → `<button>`** — no es solo ARIA: hoy tampoco se puede abrir con teclado |

`UserMenu` es el único que no es cosmético. Los demás son etiquetas mudas; ese además es un control inalcanzable sin ratón.

## ❓ Para JP

**Las etiquetas están en español CLAVADO en el DS** (`"Incluido"` / `"No incluido"`) y `PaywallUnified` no tiene prop de `labels`. En un consumidor en catalán o inglés, el lector de pantalla las anuncia en español. No lo toco aquí porque es API nueva, pero ¿lo abro como issue aparte?

## Verificación

- `pnpm typecheck` ✅
- `pnpm lint` ✅ 0 errores
- `pnpm test` ✅ **1130 pasan** (1017 previos + 113 del escáner nuevo)
- El **después** no se puede medir en producción: el DS se consume vía npm (`@jplannnou/gundo-ui`), así que esto necesita publicar versión y que `gundo-ecommerce-ui` la suba. **No hay verificación LIVE en este PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)