### PR TITLE
fix(a11y): LanguageSwitcher tenía 32px de área táctil en sus cuatro variantes

### DIFF
--- a/src/LanguageSwitcher.tsx
+++ b/src/LanguageSwitcher.tsx
@@ -110,7 +110,10 @@ function DropdownVariant({
         aria-controls={listId}
         aria-label={`Idioma actual: ${current.label}`}
         onClick={() => setOpen((v) => !v)}
-        className="flex h-8 items-center gap-1.5 rounded-lg border gu-border-border gu-bg-surface-hover px-2.5 text-sm font-medium gu-text-text transition-colors gu-h-bg-surface-raised focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary"
+        /* El disparador mide 32px de alto y vive en barras compactas, así que
+           subirlo a 44 lo deformaría. `gu-tap-44` le da el área táctil que pide
+           WCAG 2.5.5 sin tocar la píldora que se ve. */
+        className="gu-tap-44 flex h-8 items-center gap-1.5 rounded-lg border gu-border-border gu-bg-surface-hover px-2.5 text-sm font-medium gu-text-text transition-colors gu-h-bg-surface-raised focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary"
       >
         {showFlag && current.flag && <span aria-hidden="true">{current.flag}</span>}
         <span>{showLabel ? current.label : (current.short ?? current.code.toUpperCase())}</span>
@@ -143,7 +146,13 @@ function DropdownVariant({
                   role="option"
                   aria-selected={isSelected}
                   onClick={() => handleSelect(lang.code)}
-                  className={`flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm transition-colors gu-h-bg-surface-hover ${
+                  /* Las opciones se apilan en vertical: aquí NO sirve extender
+                     el área con un pseudo-elemento (se solaparía con la de
+                     arriba y la de abajo, y el toque quedaría ambiguo). El
+                     arreglo correcto es padding real: py-3 + line-height 20px
+                     de text-sm = 44px. Un menú desplegable puede permitirse ser
+                     cómodo de tocar. */
+                  className={`flex cursor-pointer items-center gap-2 px-3 py-3 text-sm transition-colors gu-h-bg-surface-hover ${
                     isSelected ? 'gu-text-primary font-medium' : 'gu-text-text'
                   }`}
                 >
@@ -198,7 +207,10 @@ function PillsVariant({
             role="radio"
             aria-checked={isSelected}
             onClick={() => onChange(lang.code)}
-            className={`flex h-7 items-center gap-1 rounded-full px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary ${
+            /* Las pills van en fila y pegadas: `gu-tap-44-y` extiende el área
+               solo en vertical, porque a lo ancho invadiría la de la pill
+               vecina y un toque en el borde no sabría a qué idioma va. */
+            className={`gu-tap-44-y flex h-7 items-center gap-1 rounded-full px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary ${
               isSelected
                 ? 'gu-bg-primary gu-text-surface'
                 : 'gu-bg-surface-hover gu-text-text-muted gu-h-text-text'
@@ -232,7 +244,10 @@ function SelectVariant({
         id={selectId}
         value={currentLanguage}
         onChange={(e) => onChange(e.target.value)}
-        className="h-8 rounded-lg border gu-border-border gu-bg-surface-hover px-2 text-sm gu-text-text outline-none transition-colors gu-fv-border-primary focus-visible:ring-1 gu-fv-ring-primary"
+        /* Un `<select>` es un elemento reemplazado: no admite pseudo-elementos,
+           así que aquí no hay truco posible — la caja tiene que ser de verdad
+           de 44px de alto (h-11). Es lo correcto para un control de formulario. */
+        className="h-11 rounded-lg border gu-border-border gu-bg-surface-hover px-2 text-sm gu-text-text outline-none transition-colors gu-fv-border-primary focus-visible:ring-1 gu-fv-ring-primary"
       >
         {languages.map((lang) => (
           <option key={lang.code} value={lang.code}>

--- a/src/__tests__/LanguageSwitcher.test.tsx
+++ b/src/__tests__/LanguageSwitcher.test.tsx
@@ -114,3 +114,68 @@ describe('LanguageSwitcher — select variant', () => {
     expect(onChange).toHaveBeenCalledWith('ca');
   });
 });
+
+/* ── Área táctil (WCAG 2.5.5 · 44×44) ─────────────────────────────────────
+ * jsdom no hace layout: `getBoundingClientRect()` devuelve ceros, así que aquí
+ * NO se puede medir geometría. Lo que sí se puede fijar es el CONTRATO: cada
+ * control declara la vía por la que llega a 44px, y borrarla rompe el test.
+ * La geometría de verdad se mide contra producción con
+ * gundo-screens/scripts/probe-tap-targets.ts, que pregunta con
+ * `elementFromPoint` si un dedo en ese punto activa el control.
+ *
+ * Por qué cada control usa una vía distinta (y no todos la misma):
+ *   - disparador del dropdown → `gu-tap-44`: tiene fondo propio y vive en
+ *     barras compactas; subirlo a h-11 lo deformaría;
+ *   - pills → `gu-tap-44-y`: van en fila, así que crecer a lo ancho invadiría
+ *     el área de la pill vecina y el toque quedaría ambiguo;
+ *   - opciones del listbox → padding real: se apilan en vertical, y ahí un
+ *     pseudo-elemento se solaparía con el de arriba y el de abajo;
+ *   - `<select>` → h-11 real: es un elemento reemplazado y no admite
+ *     pseudo-elementos. No hay truco posible.
+ */
+describe('LanguageSwitcher — área táctil ≥ 44px', () => {
+  it('el disparador del dropdown extiende el área sin agrandar la píldora', () => {
+    render(<LanguageSwitcher languages={languages} currentLanguage="es" onChange={() => {}} />);
+    const trigger = screen.getByRole('button', { name: /Idioma actual/ });
+    expect(trigger.className).toContain('gu-tap-44');
+    // La píldora se sigue viendo igual de compacta: eso es el punto.
+    expect(trigger.className).toContain('h-8');
+  });
+
+  it('las opciones del listbox llegan a 44px con padding real, no con pseudo-elemento', () => {
+    render(<LanguageSwitcher languages={languages} currentLanguage="es" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Idioma actual/ }));
+    for (const option of screen.getAllByRole('option')) {
+      // py-3 (12px × 2) + line-height 20px de text-sm = 44px.
+      expect(option.className).toContain('py-3');
+      expect(option.className).not.toContain('gu-tap-44');
+    }
+  });
+
+  it('las pills extienden el área SOLO en vertical, para no pisar a la vecina', () => {
+    render(
+      <LanguageSwitcher
+        languages={languages}
+        currentLanguage="es"
+        onChange={() => {}}
+        variant="pills"
+      />,
+    );
+    for (const pill of screen.getAllByRole('radio')) {
+      expect(pill.classList.contains('gu-tap-44-y')).toBe(true);
+      expect(pill.classList.contains('gu-tap-44')).toBe(false);
+    }
+  });
+
+  it('el select nativo tiene la caja de 44px de verdad', () => {
+    render(
+      <LanguageSwitcher
+        languages={languages}
+        currentLanguage="es"
+        onChange={() => {}}
+        variant="select"
+      />,
+    );
+    expect(screen.getByRole('combobox').className).toContain('h-11');
+  });
+});

--- a/src/ui-classes.css
+++ b/src/ui-classes.css
@@ -112,3 +112,23 @@
 .gu-z-z-overlay{z-index:var(--ui-z-overlay)}
 .gu-z-z-sticky{z-index:var(--ui-z-sticky)}
 .gu-text-brand-accent-fg{color:var(--ui-brand-accent-fg, var(--ui-surface))}
+
+/* ── Área táctil mínima (WCAG 2.5.5 · 44×44 CSS px) ───────────────────────
+   Extiende SOLO la superficie que recibe el toque, con un pseudo-elemento
+   centrado que no pinta nada. El control se sigue viendo igual de compacto:
+   agrandar la píldora para pasar la métrica sería el arreglo equivocado.
+
+   `gu-tap-44`   → los dos ejes. Para controles aislados.
+   `gu-tap-44-y` → solo vertical. Para controles en fila (pills, chips de un
+                   riel), donde crecer a lo ancho solaparía el área del vecino
+                   y volvería ambiguo el destino del toque.
+
+   Ojo con el radio: el hit-testing del navegador respeta `border-radius`, así
+   que un control muy redondeado ofrece menos área útil que su caja. El
+   pseudo-elemento es rectangular, así que recupera también las esquinas. */
+.gu-tap-44,
+.gu-tap-44-y{position:relative}
+.gu-tap-44::after,
+.gu-tap-44-y::after{content:"";position:absolute;top:50%;left:50%;height:max(100%,44px);transform:translate(-50%,-50%)}
+.gu-tap-44::after{width:max(100%,44px)}
+.gu-tap-44-y::after{width:100%}


### PR DESCRIPTION
## Qué pasaba

De la auditoría de accesibilidad del ecommerce: **161 controles táctiles por debajo del mínimo de WCAG 2.5.5 (44×44 CSS px)**. Agrupados por componente de origen en vez de por nodo, esos 161 son **68 selectores distintos** y detrás hay **4 componentes reales** repetidos muchas veces. Tres son del ecommerce ([PR del ecom](https://github.com/Gundo-Health-and-Food/gundo-ecommerce-ui/pull/1053)); **este es el del design system**.

`LanguageSwitcher` aparecía 6 veces con caja de 56×32 en el disparador del dropdown.

## Medido contra producción, antes y después

Sonda: `gundo-screens/scripts/probe-tap-targets.ts`, contra `https://ultrapersonalizacion.gundo.life` con sesión real. **No mide `getBoundingClientRect()`** — mide si un dedo que toca en el punto P activa el control, preguntando con `elementFromPoint` en los 8 puntos del perímetro de un cuadrado centrado y buscando por bisección el lado máximo que sigue respondiendo. Esa caja CSS miente en las dos direcciones: un control puede tener 44 de caja y estar tapado, o 32 de caja y 44 de área si la extiende con un pseudo-elemento.

```
ANTES · recetas iphone   idioma (LanguageSwitcher)  caja 56x32 · área táctil útil 32px
ANTES · recetas desktop  idioma (LanguageSwitcher)  caja 56x32 · área táctil útil 32px
```

Control de vida en las dos pasadas: 8.359 y 8.448 caracteres de texto renderizado. La pantalla estaba ahí.

## El arreglo

Se arreglan **las cuatro superficies** del componente, no solo la que salió medida — arreglar únicamente la que el detector vio sería perseguir el número. Cada una pide una vía distinta, y ahí está lo interesante:

| Superficie | Antes | Vía | Por qué esa y no otra |
| --- | --- | --- | --- |
| Disparador del dropdown | `h-8` (32) | `gu-tap-44` | Tiene fondo propio y vive en barras compactas: subirlo a `h-11` lo deformaría. El pseudo-elemento extiende **solo la superficie que recibe el toque**; la píldora se sigue viendo a `h-8`. |
| Pills | `h-7` (28) | `gu-tap-44-y` (solo vertical) | Van en fila y pegadas. Crecer a lo ancho invadiría el área de la vecina y un toque en el borde no sabría a qué idioma va. |
| Opciones del listbox | `py-1.5` (~30) | `py-3` real | Se apilan en vertical: un pseudo-elemento se solaparía con el de arriba y el de abajo. Un menú desplegable puede permitirse ser cómodo de tocar. |
| `<select>` nativo | `h-8` (32) | `h-11` real | Es un elemento reemplazado y **no admite pseudo-elementos**. No hay truco posible, y para un control de formulario 44px es lo correcto. |

Dos utilidades nuevas en `ui-classes.css` (`gu-tap-44` y `gu-tap-44-y`), documentadas con el porqué de cada una.

**Nota sobre el radio**: el hit-testing del navegador respeta `border-radius`, así que un control muy redondeado ofrece menos área útil que su caja. El pseudo-elemento es rectangular, así que recupera también las esquinas.

## Guarda mecánica, verificada rompiéndola

4 tests nuevos en `LanguageSwitcher.test.tsx` que fijan el **contrato** de cada variante. jsdom no hace layout (`getBoundingClientRect()` devuelve ceros), así que ahí no se puede medir geometría — lo que sí se puede fijar es que cada control declara la vía por la que llega a 44, y borrarla rompe el test.

Verificado rompiéndolo: quitar `gu-tap-44` del disparador y volver las opciones a `py-1.5` deja **2 tests en rojo**; restaurarlo vuelve a 14/14.

```
=== VERIFICAR ROMPIÉNDOLA ===
 Test Files  1 failed (1)
      Tests  2 failed | 12 passed (14)
=== restaurado ===
      Tests  14 passed (14)
```

Suite completa del repo: **1143 tests en 117 archivos, todos verdes**. `typecheck` limpio, `lint` sin errores.

## ⚠️ Esto NO llega al ecommerce con `pnpm install`

`gundo-ecommerce-ui` consume el DS como **paquete npm versionado** (`npm:@jplannnou/gundo-ui@^1.35.5`), no por `file:`. Para que el arreglo llegue hacen falta los dos pasos:

1. mergear a `main` de este repo → `publish.yml` (semantic-release) publica la versión nueva;
2. que el consumidor la recoja: **Renovate** subiendo el lockfile, o un bump manual si corre prisa.

Hasta ese momento el ecommerce sigue con el disparador a 32px, y eso es exactamente lo que se ve en la medición del PR hermano: los otros tres controles pasan a 44 sirviendo el build de la rama, y **el idioma se queda en 32**, porque su código no está en ese build.

## Lo que NO está verificado

- La geometría se midió con el componente **tal como lo renderiza el ecommerce** (que es donde salió el hallazgo). Las variantes `pills` y `select` se arreglaron por simetría y están fijadas por contrato en los tests, pero **no se midió su área táctil real en un consumidor** — no hay hoy ninguna pantalla en producción que las use.
- No se revisó el resto del catálogo del DS en busca del mismo anti-patrón. Este PR cierra el componente que la auditoría señaló, no el barrido completo de los 96 componentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
