### PR TITLE
feat: premium foundation — VerdictBanner, RangeBar, MacroRow, StatNumber + macro/serif tokens

### DIFF
--- a/src/MacroRow.tsx
+++ b/src/MacroRow.tsx
@@ -1,0 +1,131 @@
+import './ui-classes.css';
+import type { CSSProperties } from 'react';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export type MacroKind = 'kcal' | 'protein' | 'carbs' | 'fat' | 'fiber';
+
+export interface MacroCell {
+  /** Localized label, e.g. "Proteína". */
+  label: string;
+  /** Numeric value. */
+  value: number;
+  /** Unit suffix, e.g. "g" or "kcal". Omit for none. */
+  unit?: string;
+  /** Macro identity → `--ui-macro-*` token color. Or pass a raw CSS color. */
+  kind?: MacroKind | string;
+}
+
+export interface MacroRowProps {
+  /**
+   * Explicit cells (full control + ordering). If omitted, cells are built from
+   * the shorthand `calories/protein/carbs/fat/fiber` props in that order.
+   */
+  items?: MacroCell[];
+  calories?: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  fiber?: number;
+  /**
+   * `cells` — boxed grid (the hero macro summary).
+   * `strip` — compact borderless row (the meal-card footer strip).
+   */
+  variant?: 'cells' | 'strip';
+  /** Use the editorial serif for the numbers (premium B2C surfaces). */
+  serif?: boolean;
+  className?: string;
+}
+
+/* ─── Macro kind → token ─────────────────────────────────────────────── */
+
+const KIND_TOKEN: Record<MacroKind, string> = {
+  kcal: 'var(--ui-macro-kcal)',
+  protein: 'var(--ui-macro-protein)',
+  carbs: 'var(--ui-macro-carbs)',
+  fat: 'var(--ui-macro-fat)',
+  fiber: 'var(--ui-macro-fiber)',
+};
+
+const KIND_LABEL: Record<MacroKind, string> = {
+  kcal: 'kcal',
+  protein: 'Proteína',
+  carbs: 'Carbos',
+  fat: 'Grasas',
+  fiber: 'Fibra',
+};
+
+const macroColor = (kind: MacroCell['kind']): string =>
+  kind && kind in KIND_TOKEN ? KIND_TOKEN[kind as MacroKind] : (kind as string) ?? 'var(--ui-text)';
+
+/* ─── MacroRow ───────────────────────────────────────────────────────── */
+
+/**
+ * Macronutrient summary — the boxed 4-up cells of a hero/plan card, or the
+ * compact strip inside a MealCard. Numbers carry macro-identity color via the
+ * dedicated `--ui-macro-*` tokens (protein/carbs/fat no longer borrow semantic
+ * colors). Presentational only; `label`/`unit` must be pre-translated.
+ */
+export function MacroRow({
+  items,
+  calories,
+  protein,
+  carbs,
+  fat,
+  fiber,
+  variant = 'cells',
+  serif = false,
+  className = '',
+}: MacroRowProps) {
+  const cells: MacroCell[] = items ?? [];
+  if (!items) {
+    if (calories !== undefined) cells.push({ label: KIND_LABEL.kcal, value: calories, unit: '', kind: 'kcal' });
+    if (protein !== undefined) cells.push({ label: KIND_LABEL.protein, value: protein, unit: 'g', kind: 'protein' });
+    if (carbs !== undefined) cells.push({ label: KIND_LABEL.carbs, value: carbs, unit: 'g', kind: 'carbs' });
+    if (fat !== undefined) cells.push({ label: KIND_LABEL.fat, value: fat, unit: 'g', kind: 'fat' });
+    if (fiber !== undefined) cells.push({ label: KIND_LABEL.fiber, value: fiber, unit: 'g', kind: 'fiber' });
+  }
+
+  if (cells.length === 0) return null;
+
+  const numberStyle = (color: string): CSSProperties =>
+    serif ? { color, fontFamily: 'var(--ui-font-serif)' } : { color };
+
+  if (variant === 'strip') {
+    return (
+      <div className={`flex gap-1.5 ${className}`}>
+        {cells.map((c, i) => (
+          <div key={i} className="flex-1 rounded-lg px-1 py-1.5 text-center gu-bg-surface-raised">
+            <span className="block text-base font-bold leading-none tabular-nums" style={numberStyle(macroColor(c.kind))}>
+              {c.value}
+              {c.unit}
+            </span>
+            <span className="mt-1 block text-[9.5px] font-semibold uppercase tracking-wide gu-text-text-muted">
+              {c.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // cells (default)
+  return (
+    <div
+      className={`grid gap-2.5 ${className}`}
+      style={{ gridTemplateColumns: `repeat(${cells.length}, minmax(0, 1fr))` }}
+    >
+      {cells.map((c, i) => (
+        <div key={i} className="rounded-xl px-1.5 py-3 text-center gu-bg-surface-raised">
+          <span className="block text-xl font-bold leading-none tabular-nums" style={numberStyle(macroColor(c.kind))}>
+            {c.value}
+            {c.unit && <span className="text-[0.6em] font-semibold">{c.unit}</span>}
+          </span>
+          <span className="mt-1.5 block text-[10.5px] font-semibold uppercase tracking-wide gu-text-text-muted">
+            {c.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/RangeBar.tsx
+++ b/src/RangeBar.tsx
@@ -1,0 +1,132 @@
+import './ui-classes.css';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+/** Health threshold tone → range token. `neutral` uses the raised surface. */
+export type RangeTone = 'optimal' | 'good' | 'attention' | 'critical' | 'neutral';
+
+export interface RangeBand {
+  /** Band start, in the same scale as min/max. */
+  from: number;
+  /** Band end, in the same scale as min/max. */
+  to: number;
+  /** Semantic tone (mapped to a `--ui-range-*` token) or a raw CSS color. */
+  tone?: RangeTone;
+  /** Optional localized caption shown under the bar for this band. */
+  label?: string;
+}
+
+export interface RangeBarProps {
+  /** Scale minimum. */
+  min: number;
+  /** Scale maximum. */
+  max: number;
+  /** Current measured value — renders the marker. */
+  value: number;
+  /**
+   * Colored bands along the track. Omit for a plain track with just the marker.
+   * For a single optimal band, pass one band `{ from, to, tone: 'optimal' }`.
+   */
+  bands?: RangeBand[];
+  /** Marker tone (its color). Defaults to neutral `--ui-text`. */
+  markerTone?: RangeTone;
+  /** Show min/max bound labels under the ends. */
+  showBounds?: boolean;
+  /** Formatter for bound/band numbers. Defaults to 2-decimal trim. */
+  formatValue?: (n: number) => string;
+  /**
+   * Accessible label for the whole bar. Strongly recommended — describes where
+   * the value sits. If omitted, a numeric fallback is built from value + bounds.
+   */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/* ─── Helpers ────────────────────────────────────────────────────────── */
+
+/** Raw floats (e.g. 0.9924999999999998) → round to 2 decimals, trim zeros. */
+const defaultFormat = (n: number): string =>
+  Number.isFinite(n) ? String(Number(n.toFixed(2))) : String(n);
+
+const pct = (v: number, min: number, max: number): number =>
+  max === min ? 0 : Math.min(100, Math.max(0, ((v - min) / (max - min)) * 100));
+
+const toneColor = (tone: RangeTone | undefined, soft: boolean): string => {
+  switch (tone) {
+    case 'optimal':
+      return soft ? 'var(--ui-range-optimal-soft)' : 'var(--ui-range-optimal)';
+    case 'good':
+      return soft ? 'var(--ui-range-good-soft)' : 'var(--ui-range-good)';
+    case 'attention':
+      return soft ? 'var(--ui-range-attention-soft)' : 'var(--ui-range-attention)';
+    case 'critical':
+      return soft ? 'var(--ui-range-critical-soft)' : 'var(--ui-range-critical)';
+    default:
+      return soft ? 'var(--ui-surface-raised)' : 'var(--ui-text)';
+  }
+};
+
+/* ─── RangeBar ───────────────────────────────────────────────────────── */
+
+/**
+ * Multi-band range bar: a track with colored threshold bands and a value marker.
+ * Extracted from MetricRow so any surface — biomarkers, a macro vs its target,
+ * a score band — shares one accessible, theme-aware bar. A band `tone` maps to a
+ * `--ui-range-*` token; pass a raw color per band only for bespoke needs.
+ */
+export function RangeBar({
+  min,
+  max,
+  value,
+  bands = [],
+  markerTone,
+  showBounds = false,
+  formatValue = defaultFormat,
+  ariaLabel,
+  className = '',
+}: RangeBarProps) {
+  const labelledBands = bands.filter((b) => b.label);
+  const fallbackLabel = `${formatValue(value)} (${formatValue(min)}–${formatValue(max)})`;
+
+  return (
+    <div className={className}>
+      <div
+        className="relative h-2 rounded-full"
+        style={{ background: 'var(--ui-surface-raised)' }}
+        role="img"
+        aria-label={ariaLabel ?? fallbackLabel}
+      >
+        {bands.map((b, i) => (
+          <div
+            key={i}
+            className="absolute inset-y-0 rounded-full"
+            style={{
+              background:
+                b.tone && b.tone !== 'neutral'
+                  ? toneColor(b.tone, true)
+                  : (b.tone as string | undefined) ?? 'var(--ui-surface-hover)',
+              left: `${pct(b.from, min, max)}%`,
+              width: `${pct(b.to, min, max) - pct(b.from, min, max)}%`,
+            }}
+          />
+        ))}
+        <div
+          className="absolute -top-1 h-4 w-0.5 rounded"
+          style={{ background: toneColor(markerTone, false), left: `${pct(value, min, max)}%` }}
+        />
+      </div>
+
+      {(showBounds || labelledBands.length > 0) && (
+        <div className="mt-1 flex justify-between text-[10px] gu-text-text-muted">
+          {showBounds && <span>{formatValue(min)}</span>}
+          {labelledBands.map((b, i) => (
+            <span key={i} style={{ color: toneColor(b.tone, false) }}>
+              {b.label} {formatValue(b.from)}–{formatValue(b.to)}
+            </span>
+          ))}
+          {showBounds && <span>{formatValue(max)}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/StatNumber.tsx
+++ b/src/StatNumber.tsx
@@ -1,0 +1,72 @@
+import './ui-classes.css';
+import type { CSSProperties, ReactNode } from 'react';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+export type StatNumberSize = 'sm' | 'md' | 'lg' | 'xl';
+
+export interface StatNumberProps {
+  /** The number (or pre-formatted string, e.g. "2,1" / "1.980"). */
+  value: ReactNode;
+  /** Small unit suffix rendered inline after the value, e.g. "g" or "L". */
+  unit?: string;
+  /** Caption under the number (already localized). */
+  label?: string;
+  /** Optional leading icon/emoji (decorative). */
+  icon?: ReactNode;
+  /** Editorial serif for the number (premium B2C). Default sans (data-density). */
+  serif?: boolean;
+  /** Raw CSS color / token for the number. Defaults to `--ui-text`. */
+  tone?: string;
+  size?: StatNumberSize;
+  align?: 'start' | 'center';
+  className?: string;
+}
+
+/* ─── Size scale ─────────────────────────────────────────────────────── */
+
+const sizeClass: Record<StatNumberSize, string> = {
+  sm: 'text-xl',
+  md: 'text-2xl',
+  lg: 'text-3xl',
+  xl: 'text-4xl',
+};
+
+/* ─── StatNumber ─────────────────────────────────────────────────────── */
+
+/**
+ * A single headline statistic: big tabular number + optional unit, label and
+ * icon. The editorial building block of stat ribbons and hero cards. Theme-aware
+ * via `--ui-*`; `label` must be pre-translated. Set `serif` for the premium
+ * editorial look, leave it off for dashboard data-density.
+ */
+export function StatNumber({
+  value,
+  unit,
+  label,
+  icon,
+  serif = false,
+  tone = 'var(--ui-text)',
+  size = 'lg',
+  align = 'center',
+  className = '',
+}: StatNumberProps) {
+  const numberStyle: CSSProperties = serif
+    ? { color: tone, fontFamily: 'var(--ui-font-serif)' }
+    : { color: tone };
+
+  return (
+    <div className={`flex flex-col ${align === 'center' ? 'items-center text-center' : 'items-start'} ${className}`}>
+      {icon && (
+        <span className="mb-1 text-lg" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      <span className={`font-bold leading-none tabular-nums ${sizeClass[size]}`} style={numberStyle}>
+        {value}
+        {unit && <span className="text-[0.5em] font-semibold opacity-80">{unit}</span>}
+      </span>
+      {label && <span className="mt-1.5 text-xs font-medium gu-text-text-muted">{label}</span>}
+    </div>
+  );
+}

--- a/src/VerdictBanner.tsx
+++ b/src/VerdictBanner.tsx
@@ -1,0 +1,170 @@
+import './ui-classes.css';
+import type { ReactNode } from 'react';
+import { ShieldAlert, AlertTriangle, CheckCircle2, Info } from 'lucide-react';
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+/**
+ * Clinical verdict severity. Ordered by escalation:
+ * - `critical` — hard stop. Allergen, contraindication, "no apto para ti". RED.
+ *   NEVER downgrade an allergen to `caution`: the red band is a vital safety
+ *   signal, not a style choice.
+ * - `caution` — proceed with awareness (amber). e.g. "modera la ración".
+ * - `safe`    — cleared for this user (green).
+ * - `info`    — neutral context, no judgment (blue).
+ */
+export type VerdictLevel = 'critical' | 'caution' | 'safe' | 'info';
+
+export interface VerdictBannerProps {
+  /** Severity — drives color, icon and ARIA live semantics. */
+  level: VerdictLevel;
+  /** The verdict itself, already localized. e.g. "No es para ti" / "Apto para tu plan". */
+  title: string;
+  /** Clinical reasoning (already localized). Kept short; the "why" behind the verdict. */
+  reason?: ReactNode;
+  /** Override the default level icon. */
+  icon?: ReactNode;
+  /**
+   * Primary exit action — every verdict must offer a way forward so the user is
+   * never in a dead-end (the scanner "callejón" fix). e.g. "Ver alternativas".
+   */
+  action?: { label: string; onClick: () => void };
+  /** Optional secondary action (e.g. "Guardar", "Ver detalle"). */
+  secondaryAction?: { label: string; onClick: () => void };
+  /**
+   * Marks the verdict as not clinically verified — surfaces a "No verificado"
+   * chip so an AI-generated judgment is never presented as confirmed fact.
+   */
+  unverified?: boolean;
+  /** Localized label for the unverified chip. Defaults to "No verificado". */
+  unverifiedLabel?: string;
+  /** Optional trailing slot — a score letter, gauge or match ring. */
+  score?: ReactNode;
+  className?: string;
+}
+
+/* ─── Level → tokens ─────────────────────────────────────────────────── */
+
+const levelTokens: Record<VerdictLevel, { color: string; soft: string; container: string }> = {
+  // critical maps to the range-critical red (health threshold family), not the
+  // softer semantic error, so an allergen reads as unmistakably out-of-bounds.
+  critical: {
+    color: 'var(--ui-range-critical)',
+    soft: 'var(--ui-range-critical-soft)',
+    container: 'gu-border-error',
+  },
+  caution: {
+    color: 'var(--ui-warning)',
+    soft: 'var(--ui-warning-soft)',
+    container: 'gu-border-warning',
+  },
+  safe: {
+    color: 'var(--ui-success)',
+    soft: 'var(--ui-success-soft)',
+    container: 'gu-border-success',
+  },
+  info: {
+    color: 'var(--ui-info)',
+    soft: 'var(--ui-info-soft)',
+    container: 'gu-border-info',
+  },
+};
+
+const levelIcons: Record<VerdictLevel, typeof Info> = {
+  critical: ShieldAlert,
+  caution: AlertTriangle,
+  safe: CheckCircle2,
+  info: Info,
+};
+
+function DefaultIcon({ level, color }: { level: VerdictLevel; color: string }) {
+  const Icon = levelIcons[level];
+  return <Icon width={26} height={26} style={{ color }} aria-hidden="true" />;
+}
+
+/* ─── VerdictBanner ──────────────────────────────────────────────────── */
+
+/**
+ * The headline verdict for a clinical/nutrition result (scanner, product fit,
+ * meal safety). Louder than <Callout>: filled tint, prominent title, an exit
+ * action and an optional score slot — built to be the above-the-fold hero of a
+ * result screen ("verdict-first"). Theme-aware via `--ui-*` tokens;
+ * i18n-agnostic (all strings must be pre-translated).
+ *
+ * `critical` and `caution` render `role="alert"` so screen readers announce the
+ * safety verdict immediately.
+ */
+export function VerdictBanner({
+  level,
+  title,
+  reason,
+  icon,
+  action,
+  secondaryAction,
+  unverified = false,
+  unverifiedLabel = 'No verificado',
+  score,
+  className = '',
+}: VerdictBannerProps) {
+  const t = levelTokens[level];
+  const isAlert = level === 'critical' || level === 'caution';
+
+  return (
+    <div
+      role={isAlert ? 'alert' : 'status'}
+      aria-live={level === 'critical' ? 'assertive' : 'polite'}
+      className={`flex items-start gap-4 rounded-xl border-l-4 p-5 ${t.container} ${className}`}
+      style={{ background: t.soft }}
+    >
+      <span
+        className="mt-0.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-full"
+        style={{ background: 'var(--ui-surface)' }}
+      >
+        {icon || <DefaultIcon level={level} color={t.color} />}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-lg font-bold leading-tight gu-text-text">{title}</p>
+          {unverified && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide gu-text-text-muted"
+              style={{ border: '1px solid var(--ui-border)' }}
+            >
+              {unverifiedLabel}
+            </span>
+          )}
+        </div>
+
+        {reason && <div className="mt-1 text-sm gu-text-text-secondary">{reason}</div>}
+
+        {(action || secondaryAction) && (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {action && (
+              <button
+                type="button"
+                onClick={action.onClick}
+                className="gu-fv-ring-primary inline-flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm font-semibold"
+                style={{ background: t.color, color: 'var(--ui-surface)' }}
+              >
+                {action.label}
+              </button>
+            )}
+            {secondaryAction && (
+              <button
+                type="button"
+                onClick={secondaryAction.onClick}
+                className="gu-fv-ring-primary gu-h-bg-surface-hover inline-flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm font-semibold gu-text-text"
+                style={{ border: '1px solid var(--ui-border)' }}
+              >
+                {secondaryAction.label}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {score && <div className="shrink-0 self-center">{score}</div>}
+    </div>
+  );
+}

--- a/src/__tests__/MacroRow.test.tsx
+++ b/src/__tests__/MacroRow.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MacroRow } from '../MacroRow';
+
+describe('MacroRow', () => {
+  it('builds cells from shorthand macro props', () => {
+    render(<MacroRow calories={620} protein={42} carbs={48} fat={22} />);
+    expect(screen.getByText('620')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Proteína')).toBeInTheDocument();
+    expect(screen.getByText('Carbos')).toBeInTheDocument();
+  });
+
+  it('renders explicit items in order', () => {
+    render(
+      <MacroRow
+        items={[
+          { label: 'Prot', value: 18, unit: 'g', kind: 'protein' },
+          { label: 'Carb', value: 52, unit: 'g', kind: 'carbs' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Prot')).toBeInTheDocument();
+    expect(screen.getByText('Carb')).toBeInTheDocument();
+  });
+
+  it('renders nothing when empty', () => {
+    const { container } = render(<MacroRow />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('supports the compact strip variant', () => {
+    const { container } = render(<MacroRow protein={18} carbs={52} fat={14} variant="strip" />);
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText('18g')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/RangeBar.test.tsx
+++ b/src/__tests__/RangeBar.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { RangeBar } from '../RangeBar';
+
+describe('RangeBar', () => {
+  it('exposes an accessible label on the track', () => {
+    render(<RangeBar min={0} max={100} value={72} ariaLabel="Valor 72 de 100" />);
+    expect(screen.getByRole('img', { name: 'Valor 72 de 100' })).toBeInTheDocument();
+  });
+
+  it('builds a numeric fallback label when none is given', () => {
+    render(<RangeBar min={0} max={10} value={4} />);
+    expect(screen.getByRole('img', { name: '4 (0–10)' })).toBeInTheDocument();
+  });
+
+  it('renders bound labels when showBounds is set', () => {
+    render(<RangeBar min={0} max={200} value={90} showBounds />);
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
+  });
+
+  it('renders a labelled band caption', () => {
+    render(
+      <RangeBar min={0} max={100} value={50} bands={[{ from: 40, to: 80, tone: 'optimal', label: 'Óptimo' }]} />,
+    );
+    expect(screen.getByText(/Óptimo/)).toBeInTheDocument();
+    expect(screen.getByText(/40–80/)).toBeInTheDocument();
+  });
+
+  it('trims raw float bounds to 2 decimals', () => {
+    render(<RangeBar min={0.9924999999999998} max={5} value={2} showBounds />);
+    expect(screen.getByText('0.99')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/StatNumber.test.tsx
+++ b/src/__tests__/StatNumber.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { StatNumber } from '../StatNumber';
+
+describe('StatNumber', () => {
+  it('renders value, unit and label', () => {
+    render(<StatNumber value="1.980" unit="kcal" label="por día" />);
+    expect(screen.getByText('1.980')).toBeInTheDocument();
+    expect(screen.getByText('kcal')).toBeInTheDocument();
+    expect(screen.getByText('por día')).toBeInTheDocument();
+  });
+
+  it('renders without unit or label', () => {
+    render(<StatNumber value={28} />);
+    expect(screen.getByText('28')).toBeInTheDocument();
+  });
+
+  it('renders a decorative icon', () => {
+    render(<StatNumber value={140} icon={<span data-testid="ic">🍽️</span>} />);
+    expect(screen.getByTestId('ic')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/VerdictBanner.test.tsx
+++ b/src/__tests__/VerdictBanner.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { VerdictBanner } from '../VerdictBanner';
+
+describe('VerdictBanner', () => {
+  it('renders title and reason', () => {
+    render(<VerdictBanner level="safe" title="Apto para tu plan" reason="Encaja con tus objetivos." />);
+    expect(screen.getByText('Apto para tu plan')).toBeInTheDocument();
+    expect(screen.getByText('Encaja con tus objetivos.')).toBeInTheDocument();
+  });
+
+  it('uses role="alert" for critical (allergen) so it is announced', () => {
+    render(<VerdictBanner level="critical" title="No es para ti" reason="Contiene frutos secos." />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('uses role="alert" for caution', () => {
+    render(<VerdictBanner level="caution" title="Modera la ración" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('uses role="status" (not alert) for safe/info', () => {
+    render(<VerdictBanner level="info" title="Contexto" />);
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('fires the exit action so the user is never in a dead-end', () => {
+    const onClick = vi.fn();
+    render(<VerdictBanner level="critical" title="No es para ti" action={{ label: 'Ver alternativas', onClick }} />);
+    fireEvent.click(screen.getByText('Ver alternativas'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('renders the unverified chip when flagged', () => {
+    render(<VerdictBanner level="caution" title="Quizá" unverified unverifiedLabel="No verificado" />);
+    expect(screen.getByText('No verificado')).toBeInTheDocument();
+  });
+
+  it('renders the score slot', () => {
+    render(<VerdictBanner level="safe" title="Apto" score={<span data-testid="score">A</span>} />);
+    expect(screen.getByTestId('score')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/a11y.test.tsx
+++ b/src/__tests__/a11y.test.tsx
@@ -68,6 +68,10 @@ import {
   ChartTooltip,
   CodeBlock,
   BrandHeader,
+  VerdictBanner,
+  RangeBar,
+  MacroRow,
+  StatNumber,
 } from '../index';
 
 describe('Accessibility (axe)', () => {
@@ -499,6 +503,52 @@ describe('Accessibility (axe)', () => {
         tagline="Salud activa cada día"
       />,
     );
+    await expectNoA11yViolations(container);
+  });
+
+  it('VerdictBanner (critical allergen) has no a11y violations', async () => {
+    const { container } = render(
+      <VerdictBanner
+        level="critical"
+        title="No es para ti"
+        reason="Contiene frutos secos — declarado en tu perfil como alérgeno."
+        action={{ label: 'Ver alternativas', onClick: () => {} }}
+        unverified
+      />,
+    );
+    await expectNoA11yViolations(container);
+  });
+
+  it('VerdictBanner (safe) has no a11y violations', async () => {
+    const { container } = render(
+      <VerdictBanner level="safe" title="Apto para tu plan" reason="Encaja con tus objetivos de hoy." />,
+    );
+    await expectNoA11yViolations(container);
+  });
+
+  it('RangeBar has no a11y violations', async () => {
+    const { container } = render(
+      <RangeBar
+        min={0}
+        max={100}
+        value={72}
+        bands={[{ from: 40, to: 80, tone: 'optimal', label: 'Óptimo' }]}
+        showBounds
+        ariaLabel="Valor 72 dentro del rango óptimo 40–80"
+      />,
+    );
+    await expectNoA11yViolations(container);
+  });
+
+  it('MacroRow (cells) has no a11y violations', async () => {
+    const { container } = render(
+      <MacroRow calories={620} protein={42} carbs={48} fat={22} />,
+    );
+    await expectNoA11yViolations(container);
+  });
+
+  it('StatNumber has no a11y violations', async () => {
+    const { container } = render(<StatNumber value="1.980" unit="kcal" label="por día" icon="🔥" />);
     await expectNoA11yViolations(container);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,14 @@ export { MealCard } from "./MealCard";
 export type { MealCardProps, Macros, MealType } from "./MealCard";
 export { MacrosDisplay } from "./MacrosDisplay";
 export type { MacrosDisplayProps, MacroItem } from "./MacrosDisplay";
+export { MacroRow } from "./MacroRow";
+export type { MacroRowProps, MacroCell, MacroKind } from "./MacroRow";
+export { VerdictBanner } from "./VerdictBanner";
+export type { VerdictBannerProps, VerdictLevel } from "./VerdictBanner";
+export { RangeBar } from "./RangeBar";
+export type { RangeBarProps, RangeBand, RangeTone } from "./RangeBar";
+export { StatNumber } from "./StatNumber";
+export type { StatNumberProps, StatNumberSize } from "./StatNumber";
 export { ProfileHeader } from "./ProfileHeader";
 export type {
   ProfileHeaderProps,

--- a/src/theme.css
+++ b/src/theme.css
@@ -90,6 +90,23 @@
   --ui-range-critical: #ef4444;      /* outside safe range */
   --ui-range-critical-soft: rgb(239 68 68 / 0.15);
 
+  /* Macro tokens — nutrition macronutrient identity colors.
+     A dedicated family so macro UIs (MacroRow, MacrosDisplay, MealCard) stop
+     borrowing semantic tokens (protein≠"success", carbs≠"warning"): those
+     couplings broke the moment a real carb value looked like an alert. Tuned
+     for AA-as-text (≥4.5:1) on --ui-surface #292E37. kcal is intentionally
+     neutral (reads as the headline number, not a hue). Light overrides below. */
+  --ui-macro-kcal: var(--ui-text);
+  --ui-macro-kcal-soft: rgb(255 255 255 / 0.06);
+  --ui-macro-protein: #F0806A;       /* warm coral */
+  --ui-macro-protein-soft: rgb(240 128 106 / 0.15);
+  --ui-macro-carbs: #E8A13A;         /* amber */
+  --ui-macro-carbs-soft: rgb(232 161 58 / 0.15);
+  --ui-macro-fat: #7FB79A;           /* sage */
+  --ui-macro-fat-soft: rgb(127 183 154 / 0.15);
+  --ui-macro-fiber: #A3E635;         /* lime */
+  --ui-macro-fiber-soft: rgb(163 230 53 / 0.15);
+
   /* Tooltip — inverse-of-surface pattern (GitHub/Linear style).
      Tooltips on --ui-surface backgrounds become invisible if they share the
      same color, so we use the inverse: dark text-color as bg, surface as fg.
@@ -120,6 +137,10 @@
   --ui-font-family: 'Montserrat', system-ui, -apple-system, sans-serif;
   --ui-font-display: 'Quicksand', 'Montserrat', system-ui, sans-serif;
   --ui-font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+  /* Editorial serif — premium B2C surfaces (Plan, Home hero, stat numbers).
+     System serif stack: zero webfont cost, renders instantly, warm/editorial.
+     Never on dashboards (Engine/Radar/Finance/CC keep the sans data-density). */
+  --ui-font-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, 'Times New Roman', serif;
   --ui-font-size-xs: 0.75rem;
   --ui-font-size-sm: 0.875rem;
   --ui-font-size-base: 1rem;
@@ -246,6 +267,19 @@
   --ui-info: #1d4ed8;
   --ui-info-soft: rgb(37 99 235 / 0.1);
 
+  /* Macro tokens — darkened for AA-as-text (≥4.5:1) on light surface #F2F4F3.
+     -soft fills stay light-tinted for the same swatch identity. */
+  --ui-macro-kcal: var(--ui-text);
+  --ui-macro-kcal-soft: rgb(0 0 0 / 0.04);
+  --ui-macro-protein: #B23E2C;       /* darkened coral */
+  --ui-macro-protein-soft: rgb(178 62 44 / 0.1);
+  --ui-macro-carbs: #8A5A0A;         /* darkened amber */
+  --ui-macro-carbs-soft: rgb(138 90 10 / 0.1);
+  --ui-macro-fat: #2F6B4C;           /* darkened sage */
+  --ui-macro-fat-soft: rgb(47 107 76 / 0.1);
+  --ui-macro-fiber: #427012;         /* darkened lime — 5.34:1 on light */
+  --ui-macro-fiber-soft: rgb(66 112 18 / 0.1);
+
   --ui-overlay: rgb(0 0 0 / 0.3);
 
   /* Code syntax highlighting — light variant.
@@ -265,6 +299,7 @@
   --ui-font-family: 'Montserrat', system-ui, -apple-system, sans-serif;
   --ui-font-display: 'Quicksand', 'Montserrat', system-ui, sans-serif;
   --ui-font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+  --ui-font-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, 'Times New Roman', serif;
 
   /* Shadows (lighter for light theme) */
   --ui-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.05);


### PR DESCRIPTION
## Cimiento del rediseño premium ultraperso

Cuatro componentes editoriales de cara al usuario (Plan, Escáner, Mi Salud) que faltaban en el DS, + los tokens que hacen coherente el lenguaje de datos. **Aditivo, no rompe nada** (minor → v1.36.0).

### Componentes
- **VerdictBanner** — veredicto clínico héroe (verdict-first). `level: critical|caution|safe|info`. **Alérgeno = ROJO** (`--ui-range-critical`), `role="alert" aria-live="assertive"`. CTA de salida obligatoria (fix del callejón del escáner), chip "No verificado" para juicios de IA, slot de score.
- **RangeBar** — barra multi-banda extraída de `MetricRow`. `bands[]` con tono `--ui-range-*`, marcador de valor, `role="img"`+aria, `formatValue` que trima floats crudos.
- **MacroRow** — celdas 4-up (hero) + tira compacta (MealCard). Estrena `--ui-macro-*`: proteína/carbos/grasa dejan de pedir prestados los semánticos. `serif` opcional.
- **StatNumber** — número editorial grande, `serif` opcional, unidad y label.

### Tokens (`theme.css`, `:root` dark + `.theme-light`)
- `--ui-macro-{kcal,protein,carbs,fat,fiber}` (+`-soft`). **Contraste AA verificado por cálculo** como texto: 5.0–9.0:1 en ambas superficies.
- `--ui-font-serif` — stack de sistema (Iowan/Palatino), coste cero. Solo B2C premium, nunca dashboards.
- `--ui-brand-accent` **NO** se añade a propósito: ya existe como clase `gu-bg-brand-accent` con fallback; lo publica el consumer (white-label).

### Verificación
- `tsc --noEmit` limpio
- **1162 tests verde** (121 files) — incluye 5 casos axe nuevos + 4 tests unitarios
- ESLint limpio

Registrados en `index.ts` + suite a11y. Sigue el patrón canónico (`import './ui-classes.css'`, clases `gu-*`, export nombrado, `import type` separado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)