### PR TITLE
fix: keep branded badges readable

### DIFF
--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -18,8 +18,12 @@ const variantStyles: Record<Variant, string> = {
   error: 'gu-bg-error-soft gu-text-error',
   warning: 'gu-bg-warning-soft gu-text-warning',
   info: 'gu-bg-info-soft gu-text-info',
-  purple: 'gu-bg-tertiary-soft gu-text-tertiary',
-  secondary: 'gu-bg-secondary-soft gu-text-secondary',
+  // Los tokens tertiary/secondary pueden ser colores de marca oscuros. Usar
+  // el mismo color como tinta sobre su variante soft produjo ratios de 1.34:1
+  // en dark y 3.19:1 en el tenant AXA. La tinta neutral theme-aware mantiene
+  // el matiz en el fondo sin sacrificar legibilidad ni white-label.
+  purple: 'gu-bg-tertiary-soft gu-text-text-secondary',
+  secondary: 'gu-bg-secondary-soft gu-text-text-secondary',
   destructive: 'gu-bg-error-soft gu-text-error',
   outline: 'bg-transparent border gu-border-border gu-text-text',
 };

--- a/src/__tests__/Badge.test.tsx
+++ b/src/__tests__/Badge.test.tsx
@@ -19,6 +19,18 @@ describe('Badge', () => {
     expect(screen.getByText('Failed')).toBeInTheDocument();
   });
 
+  it.each(['purple', 'secondary'] as const)(
+    'uses theme-aware readable ink for the %s variant',
+    (variant) => {
+      render(<Badge variant={variant}>Visible</Badge>);
+
+      const badge = screen.getByText('Visible');
+      expect(badge).toHaveClass('gu-text-text-secondary');
+      expect(badge).not.toHaveClass('gu-text-tertiary');
+      expect(badge).not.toHaveClass('gu-text-secondary');
+    },
+  );
+
   it('renders with dot', () => {
     const { container } = render(<Badge dot>Status</Badge>);
     expect(screen.getByText('Status')).toBeInTheDocument();


### PR DESCRIPTION
## Qué corrige
- usa tinta neutral dependiente del tema en badges secondary y purple
- evita ratios 1.34:1 en dark y 3.19:1 en AXA
- añade guarda para impedir volver a usar el token de marca como tinta sobre su propio fondo suave

## Verificación
- 1,177 tests
- build
- typecheck
- lint: 0 errores (31 warnings preexistentes)