### PR TITLE
fix(a11y): guarantee premium touch targets

### DIFF
--- a/src/Button.css
+++ b/src/Button.css
@@ -19,6 +19,23 @@
   outline-offset: var(--ui-focus-ring-offset, 2px);
 }
 
+/* Preserve the compact visual rhythm while guaranteeing a 44x44 CSS px hit
+ * area. The pseudo-element participates in pointer hit-testing but paints
+ * nothing, so consumers do not need app-specific touch-target utilities. */
+.ui-btn-target {
+  position: relative;
+}
+
+.ui-btn-target::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: max(100%, 44px);
+  height: max(100%, 44px);
+  transform: translate(-50%, -50%);
+}
+
 .ui-btn-primary {
   background-color: var(--ui-primary);
   color: var(--ui-surface);

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -49,7 +49,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={disabled || loading}
-        className={`ui-focus-ring inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
+        className={`ui-focus-ring ui-btn-target inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
         {...props}
       >
         {loading ? (

--- a/src/FilterBar.tsx
+++ b/src/FilterBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 import './ui-classes.css';
+import './Button.css';
 import { useCallback, useId, useState, type ReactNode } from 'react';
 import { Check, X } from 'lucide-react';
 
@@ -78,7 +79,7 @@ export function FilterBar({
             value={searchValue}
             onChange={(e) => onSearchChange?.(e.target.value)}
             placeholder={searchPlaceholder}
-            className="h-8 w-48 rounded-lg border gu-border-border gu-bg-surface-hover pl-8 pr-3 text-sm gu-text-text placeholder:text-[var(--ui-text-muted)] outline-none transition-colors gu-fv-border-primary focus-visible:ring-1 gu-fv-ring-primary"
+            className="h-11 w-48 rounded-lg border gu-border-border gu-bg-surface-hover pl-8 pr-3 text-sm gu-text-text placeholder:text-[var(--ui-text-muted)] outline-none transition-colors gu-fv-border-primary focus-visible:ring-1 gu-fv-ring-primary"
           />
         </div>
       )}
@@ -114,7 +115,7 @@ export function FilterBar({
         <button
           type="button"
           onClick={onClearAll}
-          className="text-xs gu-text-text-muted underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary rounded"
+          className="ui-btn-target px-2 text-xs gu-text-text-muted underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary rounded"
         >
           Limpiar todo
         </button>
@@ -159,7 +160,7 @@ function FilterDropdown({ group, active, onChange }: FilterDropdownProps) {
         aria-expanded={open}
         aria-controls={listId}
         onClick={() => setOpen((v) => !v)}
-        className={`flex h-8 items-center gap-1.5 rounded-lg border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary ${
+        className={`ui-btn-target flex h-8 items-center gap-1.5 rounded-lg border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-primary ${
           hasActive
             ? 'gu-border-primary gu-bg-primary-soft gu-text-primary'
             : 'gu-border-border gu-bg-surface-hover gu-text-text'
@@ -201,7 +202,7 @@ function FilterDropdown({ group, active, onChange }: FilterDropdownProps) {
                   role="option"
                   aria-selected={isSelected}
                   onClick={() => toggle(opt.value)}
-                  className={`flex cursor-pointer items-center justify-between gap-3 px-3 py-1.5 text-sm transition-colors gu-h-bg-surface-hover ${
+                  className={`flex min-h-11 cursor-pointer items-center justify-between gap-3 px-3 py-1.5 text-sm transition-colors gu-h-bg-surface-hover ${
                     isSelected ? 'gu-text-primary' : 'gu-text-text'
                   }`}
                 >
@@ -248,7 +249,7 @@ function FilterPill({ label, onRemove }: FilterPillProps) {
         type="button"
         onClick={onRemove}
         aria-label={`Quitar filtro: ${label}`}
-        className="flex h-4 w-4 items-center justify-center rounded-full transition-colors gu-h-bg-primary gu-h-text-surface focus-visible:outline-none focus-visible:ring-1 gu-fv-ring-primary"
+        className="ui-btn-target flex h-4 w-4 items-center justify-center rounded-full transition-colors gu-h-bg-primary gu-h-text-surface focus-visible:outline-none focus-visible:ring-1 gu-fv-ring-primary"
       >
         <X className="w-2 h-2" strokeWidth={2} aria-hidden="true" />
       </button>

--- a/src/__tests__/Button.test.tsx
+++ b/src/__tests__/Button.test.tsx
@@ -32,4 +32,9 @@ describe('Button', () => {
     render(<Button variant="ghost">Ghost</Button>);
     expect(screen.getByRole('button').className).toContain('ui-btn-ghost');
   });
+
+  it.each(['sm', 'md', 'lg', 'icon'] as const)('keeps the %s target contract', (size) => {
+    render(<Button size={size}>Accessible target</Button>);
+    expect(screen.getByRole('button').className).toContain('ui-btn-target');
+  });
 });

--- a/src/__tests__/FilterBar.test.tsx
+++ b/src/__tests__/FilterBar.test.tsx
@@ -53,7 +53,13 @@ describe('FilterBar', () => {
 
   it('renders search input when searchable=true', () => {
     render(<FilterBar filters={filters} searchable />);
-    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByRole('searchbox')).toHaveClass('h-11');
+  });
+
+  it('keeps filter triggers at least 44px high', () => {
+    render(<FilterBar filters={filters} />);
+    expect(screen.getByRole('button', { name: /Categoría/ })).toHaveClass('ui-btn-target');
+    expect(screen.getByRole('button', { name: /Marca/ })).toHaveClass('ui-btn-target');
   });
 
   it('calls onSearchChange on input', () => {


### PR DESCRIPTION
## Outcome
- gives every shared Button a 44x44 effective hit area without changing visual density
- raises FilterBar search fields to 44px and extends filter actions to 44px
- keeps dropdown options at least 44px high

## Verification
- 1182 tests passed
- typecheck passed
- build passed
- lint: 0 errors (31 existing warnings)