### PR TITLE
fix(widget): el asistente creía que nadie tenía ningún test cargado

### DIFF
--- a/src/__tests__/chat-health-context.test.ts
+++ b/src/__tests__/chat-health-context.test.ts
@@ -1,0 +1,147 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from 'vitest';
+import { ChatClient } from '../widget/chat-client';
+
+/**
+ * El contrato del `healthContext` no es el tipo: es `buildFormData`.
+ *
+ * ## Por qué existe este test
+ *
+ * `ChatHealthContext` describe lo que el asistente PUEDE saber del usuario, y
+ * `buildFormData` es una lista blanca campo a campo que decide lo que de verdad
+ * viaja. Las dos se editan a mano y nada las ata. Un campo puede existir en el
+ * tipo, compilar, pasar el lint, y no salir nunca por el cable.
+ *
+ * Eso no es hipotético — es el fallo que ya ha ocurrido dos veces en este mismo
+ * componente:
+ *
+ * - `activePlanSummary`: declarado y renderizado por el Engine en el system
+ *   prompt, ningún host lo seteaba. Todo usuario CON plan recibía «todavía no
+ *   tienes plan». (audit760 RC-07)
+ * - `hasBloodTest`, `hasMicrobiotaTest`, `hasNutrigeneticTest` y
+ *   `daysUntilTrialEnds`: declarados en el DTO del Engine, consumidos por el
+ *   prompt y por el gating de venta de add-ons, y **ausentes del widget**. El
+ *   asistente creía que nadie tenía ningún test cargado, y podía ofrecerle a
+ *   alguien comprar un test que ya se había hecho. (25-ago-2026)
+ *
+ * Las dos veces se parcheó a mano y no se dejó guarda. Ésta es la guarda.
+ *
+ * ## Qué comprueba y qué NO
+ *
+ * ✅ Que todo campo declarado en `ChatHealthContext` llega al `FormData`. Los
+ *    nombres salen de leer el propio fichero fuente, no de una lista escrita a
+ *    mano aquí: una lista a mano volvería a depender de que alguien se acuerde,
+ *    que es justo lo que falló.
+ *
+ * ❌ NO comprueba la otra mitad: que el DTO del Engine no tenga campos que el
+ *    widget desconoce. Eso es exactamente lo que se nos escapó, y requiere leer
+ *    `jplannnou/Gundo_Engine` (privado) desde CI, o sea un token cruzado que
+ *    hoy no existe. Prefiero decirlo a fingir que está cubierto.
+ */
+
+// Se lee el fuente por el bundler, no por `node:fs`: el DS es una librería de
+// navegador y no lleva @types/node, así que un `readFileSync` rompería
+// `pnpm typecheck` aunque los tests pasaran. Mismo patrón que
+// `aria-prohibida.test.ts`.
+const FUENTE = import.meta.glob('../widget/chat-client.ts', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+/** Nombre y tipo declarado de cada campo de `ChatHealthContext`. */
+function camposDelContexto(): Array<{ nombre: string; tipo: string }> {
+  const fuente = Object.values(FUENTE)[0] ?? '';
+  const inicio = fuente.indexOf('export interface ChatHealthContext {');
+  expect(inicio, 'no se encontró ChatHealthContext en el fuente').toBeGreaterThan(-1);
+  const cuerpo = fuente.slice(inicio, fuente.indexOf('\n}', inicio));
+
+  // Solo declaraciones de campo en el primer nivel de indentación. Deja fuera
+  // el contenido de los bloques de comentario, que también llevan `:`.
+  const campos: Array<{ nombre: string; tipo: string }> = [];
+  for (const linea of cuerpo.split('\n')) {
+    const m = /^ {2}(\w+)\?: (.+);$/.exec(linea);
+    if (m) campos.push({ nombre: m[1], tipo: m[2] });
+  }
+  return campos;
+}
+
+/** Un valor no vacío del tipo declarado, para que la guarda `if` lo deje pasar. */
+function valorDeEjemplo(tipo: string): unknown {
+  if (tipo.endsWith('[]')) return ['x'];
+  if (tipo === 'number') return 1;
+  if (tipo === 'boolean') return true;
+  if (tipo.startsWith('Record<')) return { k: 'v' };
+  return 'x'; // string y uniones de literales de string
+}
+
+describe('el healthContext que el widget declara es el que de verdad manda', () => {
+  const campos = camposDelContexto();
+
+  it('lee el contrato del fuente, no de una lista a mano', () => {
+    // Si el parseo se rompe, todo lo de abajo pasaría en vacío — que es la
+    // forma silenciosa de que una guarda deje de guardar.
+    expect(campos.length).toBeGreaterThan(15);
+    expect(campos.map((c) => c.nombre)).toContain('activePlanSummary');
+  });
+
+  it.each(campos)('$nombre viaja en el FormData', ({ nombre, tipo }) => {
+    const client = new ChatClient({
+      apiBaseUrl: 'https://example.invalid',
+      getToken: async () => null,
+    });
+
+    // `buildFormData` es privado a propósito: el test comprueba comportamiento
+    // observable, no lo re-implementa.
+    const build = (
+      client as unknown as {
+        buildFormData: (p: Record<string, unknown>) => FormData;
+      }
+    ).buildFormData.bind(client);
+
+    const fd = build({ message: 'hola', [nombre]: valorDeEjemplo(tipo) });
+
+    expect(
+      fd.has(nombre),
+      `'${nombre}' está en ChatHealthContext pero buildFormData no lo manda. ` +
+        `El Engine nunca lo verá: añádelo a la lista blanca de buildFormData.`,
+    ).toBe(true);
+  });
+
+  it('los flags booleanos se omiten cuando son falsos, no se mandan como "false"', () => {
+    const client = new ChatClient({
+      apiBaseUrl: 'https://example.invalid',
+      getToken: async () => null,
+    });
+    const build = (
+      client as unknown as {
+        buildFormData: (p: Record<string, unknown>) => FormData;
+      }
+    ).buildFormData.bind(client);
+
+    const fd = build({ message: 'hola', hasBloodTest: false, hasFamilyGroup: false });
+
+    // Sobre multipart todo viaja como string, y 'false' es una cadena no vacía:
+    // que el Engine la lea como `false` depende de cómo la coaccione
+    // class-transformer. No mandarla no depende de nada.
+    expect(fd.has('hasBloodTest')).toBe(false);
+    expect(fd.has('hasFamilyGroup')).toBe(false);
+  });
+
+  it('daysUntilTrialEnds manda el 0, que significa «el trial termina hoy»', () => {
+    const client = new ChatClient({
+      apiBaseUrl: 'https://example.invalid',
+      getToken: async () => null,
+    });
+    const build = (
+      client as unknown as {
+        buildFormData: (p: Record<string, unknown>) => FormData;
+      }
+    ).buildFormData.bind(client);
+
+    // El error clásico de la lista blanca: `if (params.x)` se come el 0. Aquí
+    // el 0 es información, no ausencia — y el rango del Engine empieza en 0.
+    const fd = build({ message: 'hola', daysUntilTrialEnds: 0 });
+    expect(fd.get('daysUntilTrialEnds')).toBe('0');
+  });
+});

--- a/src/widget/ChatHistorySection.tsx
+++ b/src/widget/ChatHistorySection.tsx
@@ -50,7 +50,7 @@ export function ChatHistorySection({ client, locale = 'es', onResume, labels }: 
       <div className="flex flex-col items-center justify-center h-full p-6 text-center">
         <MessageCircle className="w-10 h-10 gu-text-text-muted mb-3" aria-hidden="true" />
         <p className="text-sm gu-text-text-muted">
-          {labels?.empty ?? 'Todavía no tenés charlas. Empezá una desde el Asistente.'}
+          {labels?.empty ?? 'Todavía no tienes charlas. Empieza una desde el Asistente.'}
         </p>
       </div>
     );

--- a/src/widget/chat-client.ts
+++ b/src/widget/chat-client.ts
@@ -117,6 +117,25 @@ export interface ChatHealthContext {
   conditionDetails?: Record<string, string | number | boolean>;
 
   /**
+   * Tests already loaded in the user's profile. The Engine renders these into
+   * the system prompt AND gates add-on upsell on them (`blockedByProfileFlag`
+   * in its product catalog): without them the assistant assumes NOBODY has any
+   * test loaded, and can offer to sell a test the user already took.
+   *
+   * They are flags, not payloads — the assistant never sees the results here.
+   */
+  hasBloodTest?: boolean;
+  hasMicrobiotaTest?: boolean;
+  hasNutrigeneticTest?: boolean;
+
+  /**
+   * Days left in the user's trial. The Engine reads it to decide whether to
+   * mention the trial at all; absent means "not in a trial", which is why the
+   * host must send it whenever it knows better. Engine range: 0–365.
+   */
+  daysUntilTrialEnds?: number;
+
+  /**
    * Family group: the user shops for a household with several profiles. Lets the
    * assistant offer/use per-member personalization (the scanner, recommendations
    * and plan all personalize per member). The host sets these from its family
@@ -198,6 +217,16 @@ export class ChatClient {
     if (params.activePlanSummary) fd.append('activePlanSummary', params.activePlanSummary);
     if (params.activeShoppingContext)
       fd.append('activeShoppingContext', params.activeShoppingContext);
+    // Flags de tests: se mandan SOLO cuando son ciertos, igual que
+    // hasFamilyGroup. Ausencia = false. Es deliberado: sobre multipart todo
+    // viaja como string, y aunque el Engine tenga enableImplicitConversion,
+    // mandar 'false' depende de cómo lo coaccione class-transformer. No
+    // mandarlo no depende de nada.
+    if (params.hasBloodTest) fd.append('hasBloodTest', 'true');
+    if (params.hasMicrobiotaTest) fd.append('hasMicrobiotaTest', 'true');
+    if (params.hasNutrigeneticTest) fd.append('hasNutrigeneticTest', 'true');
+    if (typeof params.daysUntilTrialEnds === 'number')
+      fd.append('daysUntilTrialEnds', String(params.daysUntilTrialEnds));
     if (params.hasFamilyGroup) fd.append('hasFamilyGroup', 'true');
     if (typeof params.familyMemberCount === 'number')
       fd.append('familyMemberCount', String(params.familyMemberCount));
@@ -219,7 +248,7 @@ export class ChatClient {
     });
 
     if (!response.ok || !response.body) {
-      yield { type: 'error', data: 'No pude conectar con el asistente. Intentá de nuevo en unos momentos.' };
+      yield { type: 'error', data: 'No pude conectar con el asistente. Inténtalo de nuevo en unos momentos.' };
       return;
     }
 


### PR DESCRIPTION
El DTO del Engine declara **cuatro campos que el widget nunca ha podido enviar**: `hasBloodTest`, `hasMicrobiotaTest`, `hasNutrigeneticTest` y `daysUntilTrialEnds`.

No son restos muertos del servidor. El Engine los renderiza **en el system prompt** (`gemini-chat.adapter.ts`, `bedrock-chat.adapter.ts`) y los usa para **gatear la venta de add-ons** (`blockedByProfileFlag` de su catálogo de producto).

**Efecto vivo:** el asistente da por hecho que NINGÚN usuario tiene analítica, microbiota ni nutrigenética cargadas. Puede ofrecerle a alguien que compre un test que ya se hizo.

Los tres flags salen del mismo objeto de usuario que el host ya tiene en Redux (`user.testsCompleted`). `daysUntilTrialEnds` se declara porque es contrato del Engine, pero **ecommerce-ui no puede poblarlo**: no existe el concepto de trial en el producto, y `renewalDate` **no** es equivalente — es la fecha del próximo cobro de alguien que ya paga.

## La guarda, que es la mitad que importa

Este fallo **ya había ocurrido en este mismo componente**: `activePlanSummary` estaba declarado y renderizado por el Engine, ningún frontend lo seteaba, y todo usuario CON plan recibía «todavía no tienes plan» (audit760 RC-07). Se parcheó a mano y no se dejó guarda. Por eso hay ahora otros cuatro.

`chat-health-context.test.ts` lee los campos **del propio fuente** —no de una lista a mano, que volvería a depender de que alguien se acuerde— y comprueba que cada uno llega de verdad al `FormData`. Porque el contrato no es el tipo: es `buildFormData`, una lista blanca campo a campo. Un campo puede existir en el `.d.ts`, compilar, pasar el lint y **no salir nunca por el cable**.

**Verificado por mutación:** quitando el `append` de `hasMicrobiotaTest`, el test falla y dice exactamente qué hacer.

Dos casos límite cubiertos, los dos reales:
- los booleanos se **omiten** cuando son falsos en vez de mandar `'false'` (sobre multipart todo viaja como string, y `'false'` es una cadena no vacía)
- `daysUntilTrialEnds: 0` **sí** viaja: el 0 es «el trial acaba hoy», no ausencia. Es el fallo clásico del `if (params.x)`

## Y de paso, voseo en copy de cara al usuario

- «Intentá de nuevo» → «Inténtalo de nuevo»
- «Todavía no tenés charlas. Empezá una» → «no tienes / Empieza una»

## Lo que esta guarda NO cubre, dicho explícitamente

No comprueba que el DTO del Engine no tenga campos que el widget desconozca — que es justo lo que se nos escapó. Eso exige leer `jplannnou/Gundo_Engine` (privado) desde CI: un token cruzado que hoy no existe. Prefiero decirlo a fingir que está cubierto.

## Verificación

- `tsc --noEmit` limpio
- `eslint` 0 errores
- **1233/1233** tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)