### PR TITLE
chore: heredar política central de Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "local>jplannnou/renovate-config"
   ],
   "schedule": ["before 9am on monday"],
   "timezone": "Europe/Madrid",


### PR DESCRIPTION
Conserva las reglas específicas del repositorio y cambia únicamente la base común. Así recibe límites de concurrencia, agrupación, ventana semanal, enfriamiento de 3 días y aprobación obligatoria de cambios mayores.