### PR TITLE
fix: asegurar contraste AA en badges y macros

### DIFF
--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -13,7 +13,10 @@ interface BadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'children'> {
 }
 
 const variantStyles: Record<Variant, string> = {
-  default: 'gu-bg-surface-hover gu-text-text-secondary',
+  // `text-secondary` queda en 4.30:1 sobre `surface-hover` en el tema oscuro
+  // de Ultra. El badge es texto pequeño (12 px), por lo que necesita la tinta
+  // principal para conservar AA en consumidores que personalizan los tokens.
+  default: 'gu-bg-surface-hover gu-text-text',
   success: 'gu-bg-success-soft gu-text-success',
   error: 'gu-bg-error-soft gu-text-error',
   warning: 'gu-bg-warning-soft gu-text-warning',

--- a/src/MacroRow.tsx
+++ b/src/MacroRow.tsx
@@ -100,7 +100,7 @@ export function MacroRow({
               {c.value}
               {c.unit}
             </span>
-            <span className="mt-1 block text-[9.5px] font-semibold uppercase tracking-wide gu-text-text-muted">
+            <span className="mt-1 block text-[9.5px] font-semibold uppercase tracking-wide gu-text-text-secondary">
               {c.label}
             </span>
           </div>

--- a/src/__tests__/Badge.test.tsx
+++ b/src/__tests__/Badge.test.tsx
@@ -5,7 +5,10 @@ import { Badge } from '../Badge';
 describe('Badge', () => {
   it('renders children', () => {
     render(<Badge>Active</Badge>);
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    const badge = screen.getByText('Active');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass('gu-text-text');
+    expect(badge).not.toHaveClass('gu-text-text-secondary');
   });
 
   it('renders with success variant', () => {

--- a/src/__tests__/MacroRow.test.tsx
+++ b/src/__tests__/MacroRow.test.tsx
@@ -33,5 +33,7 @@ describe('MacroRow', () => {
     const { container } = render(<MacroRow protein={18} carbs={52} fat={14} variant="strip" />);
     expect(container.firstChild).not.toBeNull();
     expect(screen.getByText('18g')).toBeInTheDocument();
+    expect(screen.getByText('Proteína')).toHaveClass('gu-text-text-secondary');
+    expect(screen.getByText('Proteína')).not.toHaveClass('gu-text-text-muted');
   });
 });


### PR DESCRIPTION
## Resultado

- eleva la tinta del badge neutro para cumplir WCAG AA sobre surface-hover
- usa text-secondary en las etiquetas compactas de MacroRow
- agrega guardas unitarias de clases accesibles

## Verificación

- 1.206 pruebas verdes
- 78 pruebas dirigidas de Badge, MacroRow y axe
- lint: 0 errores
- build: verde