### PR TITLE
fix: harden detail tabs keyboard navigation

### DIFF
--- a/src/DetailTabs.tsx
+++ b/src/DetailTabs.tsx
@@ -1,5 +1,12 @@
 import './ui-classes.css';
-import { useState, useEffect, type ReactNode } from 'react';
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
 
 /**
  * Generic tabbed detail viewer with optional premium gating.
@@ -41,7 +48,7 @@ export interface DetailTabsProps<TId extends string = string> {
   lockedContent?: ReactNode | ((tab: DetailTabDefinition<TId>) => ReactNode);
   /** ARIA label for the tablist (defaults to "Detalle") */
   ariaLabel?: string;
-  /** Optional id prefix for ARIA wiring (defaults to "detail") */
+  /** Optional id prefix for ARIA wiring (unique per instance when omitted) */
   idPrefix?: string;
   className?: string;
 }
@@ -54,12 +61,18 @@ export function DetailTabs<TId extends string = string>({
   isPremium = true,
   lockedContent,
   ariaLabel = 'Detalle',
-  idPrefix = 'detail',
+  idPrefix,
   className = '',
 }: DetailTabsProps<TId>) {
+  const generatedId = useId();
+  const resolvedIdPrefix = idPrefix ?? `detail-${generatedId.replace(/:/g, '')}`;
+  const tabRefs = useRef(new Map<TId, HTMLButtonElement>());
   const initialTab = defaultTab ?? tabs[0]?.id;
   const [internalActive, setInternalActive] = useState<TId | undefined>(initialTab);
-  const active = activeTab ?? internalActive;
+  const requestedActive = activeTab ?? internalActive;
+  const active = tabs.some((tab) => tab.id === requestedActive)
+    ? requestedActive
+    : tabs[0]?.id;
 
   // If controlled `activeTab` changes externally, no internal sync needed
   // (we just read `active`). If uncontrolled and `defaultTab` changes, follow it.
@@ -68,6 +81,16 @@ export function DetailTabs<TId extends string = string>({
       setInternalActive(defaultTab);
     }
   }, [defaultTab, activeTab]);
+
+  useEffect(() => {
+    if (
+      activeTab === undefined &&
+      internalActive !== undefined &&
+      !tabs.some((tab) => tab.id === internalActive)
+    ) {
+      setInternalActive(tabs[0]?.id);
+    }
+  }, [activeTab, internalActive, tabs]);
 
   if (!active || tabs.length === 0) {
     return null;
@@ -78,6 +101,33 @@ export function DetailTabs<TId extends string = string>({
       setInternalActive(id);
     }
     onTabChange?.(id);
+  }
+
+  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>, currentId: TId) {
+    const currentIndex = tabs.findIndex((tab) => tab.id === currentId);
+    let nextIndex: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        nextIndex = (currentIndex + 1) % tabs.length;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = tabs.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    selectTab(nextTab.id);
+    tabRefs.current.get(nextTab.id)?.focus();
   }
 
   const activeTabDef = tabs.find((t) => t.id === active);
@@ -116,10 +166,19 @@ export function DetailTabs<TId extends string = string>({
               key={t.id}
               role="tab"
               aria-selected={selected}
-              aria-controls={`${idPrefix}-panel-${t.id}`}
-              id={`${idPrefix}-tab-${t.id}`}
+              aria-controls={`${resolvedIdPrefix}-panel`}
+              id={`${resolvedIdPrefix}-tab-${t.id}`}
               type="button"
+              tabIndex={selected ? 0 : -1}
+              ref={(element) => {
+                if (element) {
+                  tabRefs.current.set(t.id, element);
+                } else {
+                  tabRefs.current.delete(t.id);
+                }
+              }}
               onClick={() => selectTab(t.id)}
+              onKeyDown={(event) => handleTabKeyDown(event, t.id)}
               className={`flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 gu-fv-ring-focus-ring-color ${
                 selected
                   ? 'gu-bg-primary gu-text-surface'
@@ -140,8 +199,8 @@ export function DetailTabs<TId extends string = string>({
 
       <div
         role="tabpanel"
-        id={`${idPrefix}-panel-${active}`}
-        aria-labelledby={`${idPrefix}-tab-${active}`}
+        id={`${resolvedIdPrefix}-panel`}
+        aria-labelledby={`${resolvedIdPrefix}-tab-${active}`}
         className="rounded-2xl border gu-border-border gu-bg-surface p-4 md:p-5"
       >
         {renderPanel()}

--- a/src/__tests__/DetailTabs.test.tsx
+++ b/src/__tests__/DetailTabs.test.tsx
@@ -41,6 +41,84 @@ describe('DetailTabs', () => {
     expect(onTabChange).toHaveBeenCalledWith('c');
   });
 
+  it.each([
+    ['ArrowRight', 'Tab B', 'Content B'],
+    ['ArrowLeft', 'Tab C', 'Content C'],
+    ['Home', 'Tab A', 'Content A'],
+    ['End', 'Tab C', 'Content C'],
+  ])('selects and focuses the expected tab with %s', (key, label, content) => {
+    render(<DetailTabs tabs={baseTabs} isPremium />);
+    const firstTab = screen.getByRole('tab', { name: /Tab A/ });
+
+    firstTab.focus();
+    fireEvent.keyDown(firstTab, { key });
+
+    expect(screen.getByRole('tab', { name: label })).toHaveFocus();
+    expect(screen.getByText(content)).toBeInTheDocument();
+  });
+
+  it('wraps from the last tab to the first with ArrowRight', () => {
+    render(<DetailTabs tabs={baseTabs} defaultTab="c" isPremium />);
+    const lastTab = screen.getByRole('tab', { name: /Tab C/ });
+
+    lastTab.focus();
+    fireEvent.keyDown(lastTab, { key: 'ArrowRight' });
+
+    expect(screen.getByRole('tab', { name: /Tab A/ })).toHaveFocus();
+    expect(screen.getByText('Content A')).toBeInTheDocument();
+  });
+
+  it('exposes only the active tab in the sequential tab order', () => {
+    render(<DetailTabs tabs={baseTabs} />);
+
+    expect(screen.getByRole('tab', { name: /Tab A/ })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('tab', { name: /Tab B/ })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('tab', { name: /Tab C/ })).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('keeps keyboard focus inside the DetailTabs instance that received the key', () => {
+    render(
+      <>
+        <DetailTabs tabs={baseTabs} ariaLabel="First detail" isPremium />
+        <DetailTabs tabs={baseTabs} ariaLabel="Second detail" isPremium />
+      </>,
+    );
+    const secondTablist = screen.getByRole('tablist', { name: 'Second detail' });
+    const secondFirstTab = secondTablist.querySelector<HTMLButtonElement>('[role="tab"]');
+
+    secondFirstTab?.focus();
+    fireEvent.keyDown(secondFirstTab as HTMLButtonElement, { key: 'ArrowRight' });
+
+    expect(secondTablist.querySelector('[aria-selected="true"]')).toHaveTextContent('Tab B');
+    expect(secondTablist.querySelector('[aria-selected="true"]')).toHaveFocus();
+  });
+
+  it('falls back to a valid tab when an uncontrolled active tab is removed', () => {
+    const { rerender } = render(<DetailTabs tabs={baseTabs} defaultTab="c" isPremium />);
+
+    rerender(<DetailTabs tabs={baseTabs.slice(0, 2)} isPremium />);
+
+    expect(screen.getByRole('tab', { name: /Tab A/ })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('tab', { name: /Tab A/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Content A')).toBeInTheDocument();
+  });
+
+  it('falls back to a valid tab when controlled activeTab is not present', () => {
+    render(<DetailTabs tabs={baseTabs} activeTab={'missing' as 'a'} isPremium />);
+
+    expect(screen.getByRole('tab', { name: /Tab A/ })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByText('Content A')).toBeInTheDocument();
+  });
+
+  it('wires every tab to the stable panel rendered in the DOM', () => {
+    render(<DetailTabs tabs={baseTabs} />);
+    const panel = screen.getByRole('tabpanel');
+
+    for (const tab of screen.getAllByRole('tab')) {
+      expect(tab).toHaveAttribute('aria-controls', panel.id);
+    }
+  });
+
   it('shows lock indicator on premium tabs when not premium', () => {
     render(<DetailTabs tabs={baseTabs} isPremium={false} />);
     const premiumTab = screen.getByRole('tab', { name: /Tab B/ });
@@ -100,7 +178,7 @@ describe('DetailTabs', () => {
   it('uses idPrefix for ARIA wiring', () => {
     render(<DetailTabs tabs={baseTabs} idPrefix="custom" />);
     expect(screen.getByRole('tab', { name: /Tab A/ })).toHaveAttribute('id', 'custom-tab-a');
-    expect(screen.getByRole('tabpanel')).toHaveAttribute('id', 'custom-panel-a');
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('id', 'custom-panel');
   });
 
   it('uses ariaLabel on tablist', () => {


### PR DESCRIPTION
## Resultado

Hace que `DetailTabs` sea un patrón accesible y seguro para múltiples instancias y catálogos dinámicos.

## Cambios

- navegación con ArrowLeft/ArrowRight, Home y End, con wrap
- roving tabindex y foco acotado por refs
- IDs únicos por instancia con `useId`
- fallback válido si el tab controlado/no controlado desaparece
- panel estable: todos los `aria-controls` apuntan a un destino montado
- cobertura de multiinstancia, foco, orden de tabulación, tabs dinámicos e IDREF

## Verificación

- `pnpm test`: 122 archivos, 1.216 pruebas verdes
- `pnpm run typecheck`: verde
- `pnpm run build`: verde
- ESLint dirigido: verde
- revisión P0/P1/P2: sin hallazgos pendientes